### PR TITLE
Document disabling USB4

### DIFF
--- a/hardware/pcie-bandwidth.md
+++ b/hardware/pcie-bandwidth.md
@@ -284,6 +284,7 @@ Without this, NCCL P2P operations lock up. This is required on virtually all RTX
 - **Resizable BAR:** Enabled (default)
 - **Above 4G Decoding:** Enabled
 - **SR-IOV:** Enabled
+- **USB4 Support:** Disabled (without this, 6+ will not POST)
 - **Slot 6 Warning:** On WRX90E-SAGE SE, slot 6 is limited to Gen5 x8 speed
 
 ### Filesystem Warning


### PR DESCRIPTION
This is required to have enough mappable space available. For me, 5 would POST but the card would not function. 6 would not even POST. Disabling the USB4 hardware fixed it. (