### PR TITLE
docs: June 2026 cu132 refresh for Qwen3.5-397B (benchmarks, YaRN correction, MTP A/B, Responses API)

### DIFF
--- a/models/qwen35-397b.md
+++ b/models/qwen35-397b.md
@@ -653,9 +653,15 @@ June 2026 on the voipmonitor images and reproduced on upstream 0.5.12.post1:
    ```
 
    sglang's flat `config.update()` replaces `text_config` with a plain dict →
-   `AssertionError` in `get_hf_text_config`. See sglang Discussion #26440;
-   an upstream issue draft covering both failure modes exists but is unfiled
-   as of 2026-06-11.
+   `AssertionError` in `get_hf_text_config`. See sglang Discussion #26440.
+   Both failure modes are now tracked upstream as
+   [sgl-project/sglang#27974](https://github.com/sgl-project/sglang/issues/27974),
+   with a fix open at
+   [sgl-project/sglang#27983](https://github.com/sgl-project/sglang/pull/27983)
+   (recursive override + partial rope-dict merge; validated against this exact
+   checkpoint). Once that merges, the plain `--json-model-override-args`
+   flag works again and the patched-checkpoint-dir method below becomes a
+   fallback for older builds.
 
 **Working method — patch the checkpoint's `config.json`:** make a local model
 dir that symlinks every checkpoint file and carries one real, patched

--- a/models/qwen35-397b.md
+++ b/models/qwen35-397b.md
@@ -85,6 +85,44 @@ ctx\conc     1      2      4      8     16     32      64   128
 | Multi-user (c=64) | SGLang b12x, no MTP | **1551** |
 | High concurrency (c=128) | vLLM | **2277** |
 
+### AWQ + MTP, cu130 vs cu132 (June 2026, same host, same flags)
+
+`QuantTrio/Qwen3.5-397B-A17B-AWQ`, TP=4, EAGLE steps=4/draft=5,
+`--prefill-attention-backend flashinfer --decode-attention-backend b12x
+--page-size 64`, 4× RTX PRO 6000 Workstation, 30 s per cell, ctx = prefix
+tokens before generation.
+
+**`voipmonitor/sglang:cu130`** (b12x 0.10):
+
+```
+ctx\conc      1      4     16
+   0      244.3  617.3  1206.1
+  16k     230.9  555.5  1168.8
+```
+
+**`voipmonitor/sglang:cu132`** (b12x 0.20 + fixes):
+
+```
+ctx\conc      1      4     16
+   0      233.2  636.3  1226.3
+  16k     224.0  590.3  1160.0
+```
+
+cu132 vs cu130 at ctx=0: **c=1 −4.5%, c=4 +3.1%, c=16 +1.7%**. The
+single-stream dip is the dropped fusion pass (replaced by the auto max-size
+rework); concurrency gains come from b12x 0.20 and the crossover fix. On the
+final production config (YaRN-524K patched checkpoint + `--schedule-policy
+lpm`, steps=4/draft=5), cu132 measured **240.1 c=1 / 631.7 c=4** at ctx=0 —
+within 2% of cu130 single-stream with everything else better.
+
+> These are AWQ numbers with the b12x decode backend — not directly comparable
+> to the April AWQ row (152 tok/s), which predates
+> `--decode-attention-backend b12x`, `--page-size 64`, and the Workstation
+> MoE configs.
+
+Prefill throughput is unchanged within noise (cu132: 17.3K tok/s @ 8K ctx,
+16.3K @ 32K, 11.5K @ 128K; TTFT 0.55 s / 2.09 s / 11.5 s).
+
 ---
 
 ## Table of Contents (detailed sections)
@@ -97,7 +135,7 @@ ctx\conc     1      2      4      8     16     32      64   128
 - [Launch Commands -- vLLM](#launch-commands----vllm)
 - [Docker Images](#docker-images)
 - [MTP / Speculative Decoding](#mtp--speculative-decoding)
-- [YaRN Extended Context (up to 900K)](#yarn-extended-context-up-to-900k)
+- [YaRN Extended Context](#yarn-extended-context)
 - [Quantization Details](#quantization-details)
 - [Thinking Mode Configuration](#thinking-mode-configuration)
 - [Detailed Benchmark Tables](#detailed-benchmark-tables)
@@ -264,6 +302,51 @@ docker run --gpus '"device=0,1,2,3"' \
 
 > **AWQ note:** SGLang auto-detects AWQ quantization from the config — do NOT add `--quantization`. The `--mamba-scheduler-strategy extra_buffer` flag is required because AWQ uses VLM format (`Qwen3_5MoeForConditionalGeneration`).
 
+### AWQ-INT4 on cu132, 4x GPUs, EAGLE 4/5 + lpm (240 tok/s c=1 / 1226 tok/s c=16)
+
+```bash
+docker run --gpus '"device=0,1,2,3"' \
+  --ipc=host --shm-size=8g --network=host \
+  -v ~/.cache/huggingface:/root/.cache/huggingface \
+  -v jit-cache:/cache/jit \
+  -e NCCL_P2P_LEVEL=SYS \
+  -e NCCL_IB_DISABLE=1 \
+  -e SAFETENSORS_FAST_GPU=1 \
+  -e OMP_NUM_THREADS=8 \
+  -e SGLANG_ENABLE_SPEC_V2=true \
+  voipmonitor/sglang:cu132 \
+  python3 -m sglang.launch_server \
+    --model-path QuantTrio/Qwen3.5-397B-A17B-AWQ \
+    --served-model-name Qwen3.5 \
+    --reasoning-parser qwen3 --tool-call-parser qwen3_coder \
+    --tensor-parallel-size 4 \
+    --kv-cache-dtype fp8_e4m3 \
+    --trust-remote-code \
+    --cuda-graph-max-bs 64 --max-running-requests 64 \
+    --mem-fraction-static 0.90 --chunked-prefill-size 16384 \
+    --host 0.0.0.0 --port 5000 \
+    --prefill-attention-backend flashinfer \
+    --decode-attention-backend b12x \
+    --page-size 64 \
+    --enable-pcie-oneshot-allreduce \
+    --pcie-oneshot-allreduce-max-size auto \
+    --enable-metrics --sleep-on-idle \
+    --mamba-scheduler-strategy extra_buffer \
+    --speculative-algorithm EAGLE \
+    --speculative-num-steps 4 \
+    --speculative-eagle-topk 1 \
+    --speculative-num-draft-tokens 5 \
+    --schedule-policy lpm \
+    --context-length 262144
+```
+
+> **cu132 notes:** the flag is `--speculative-algorithm EAGLE` on this tree
+> (cu130 used `--speculative-algo NEXTN`). For >262K context, point
+> `--model-path` at a YaRN-patched checkpoint dir (see the YaRN section) and
+> add `SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN=1` +
+> `--context-length 524288` — **do not** use `--json-model-override-args`
+> for rope scaling (silent no-op on this model family).
+
 ## Launch Commands -- vLLM
 
 ### Recommended: Docker run (4x GPUs, MTP=2)
@@ -357,11 +440,12 @@ command: >
 | Image | Purpose |
 |---|---|
 | **`voipmonitor/sglang:cu130`** | **Recommended.** SGLang with SM120 patches, FlashInfer from source (PR #2913 GDC), b12x 0.7.1 attention+MoE backend, PCIe allreduce, NCCL graph. PyTorch 2.11 cu130. |
+| **`voipmonitor/sglang:cu132`** | SGLang refresh (June 2026): CUDA 13.2.1, PyTorch 2.12.0+cu132 wheels, patched NCCL 2.30.4, cuBLAS 13.4.1/cuDNN 9.22, FlashInfer 0.6.12, **b12x 0.20.0**, fork @ `260194aa`. **Flag change:** `--enable-pcie-oneshot-allreduce-fusion` is gone — use `--pcie-oneshot-allreduce-max-size auto`. |
 | **`voipmonitor/vllm:cu130`** | **Recommended.** vLLM with SM120 patches, FlashInfer from source, cherry-picked PRs (#35675, #35936, #37132). |
 | `lmsysorg/sglang:dev-cu13` | Official SGLang nightly for CUDA 13. May need `pip install transformers>=5.3,<5.4`. |
 | `vllm/vllm-openai:cu130-nightly` | Official vLLM nightly for CUDA 13 |
 
-Source & Dockerfiles: [github.com/voipmonitor/blackwell-llm-docker](https://github.com/voipmonitor/blackwell-llm-docker)
+Source & Dockerfiles: [github.com/local-inference-lab/blackwell-llm-docker](https://github.com/local-inference-lab/blackwell-llm-docker)
 
 ### voipmonitor/sglang:cu130 (recommended for SGLang)
 
@@ -373,6 +457,43 @@ Pre-built image with all SM120 patches:
 - NCCL graph XML baked in at `/etc/nccl_graph_opt.xml`
 - Model profiles in `/profiles/`
 - sgl-kernel built from source
+
+### voipmonitor/sglang:cu132 (June 2026 refresh)
+
+Refreshed stack matching driver 595.71+ (CUDA 13.2). Same April fork tree as
+cu130 (the June upstream CUDA-graph/attention refactor would require a full
+b12x backend port), rebuilt on a modern platform:
+
+- CUDA 13.2.1, official PyTorch 2.12.0+cu132 wheels (no more source-built torch)
+- Patched NCCL 2.30.4 (`local-inference-lab/nccl-canonical`, PCIe-tuned)
+- FlashInfer 0.6.12 (PR #2913 merged — no source build needed)
+- **b12x 0.20.0** (was 0.7.2–0.10) with three integration fixes: NCCL-backed
+  IPC exchange group (b12x ≥0.16 rejects gloo — without the fix custom
+  allreduce **silently disables itself** and you lose the PCIe oneshot path),
+  stream-affinity opt-out (fixes a crash during EAGLE draft CUDA-graph
+  capture), and the re-wired crossover autotune
+- Tuned Triton MoE configs installed under `triton_3_7_0/` (torch 2.12 ships
+  triton 3.7.0 — configs are version-keyed and 3_6_0 configs are ignored),
+  for both Server and **Workstation** Edition device names
+- Cherry-pick layer (`cu132-picks`) including a port of open PR
+  [sgl-project/sglang#25881](https://github.com/sgl-project/sglang/pull/25881),
+  giving `/v1/responses` full function-tool support (validated live with
+  Hermes Agent and Codex-style flows)
+
+**Flag change when moving cu130 → cu132:**
+
+```bash
+# cu130 (old)
+--enable-pcie-oneshot-allreduce --enable-pcie-oneshot-allreduce-fusion
+
+# cu132 (new) — the fusion flag no longer exists
+--enable-pcie-oneshot-allreduce --pcie-oneshot-allreduce-max-size auto
+```
+
+`auto` benchmarks the NCCL-vs-oneshot crossover at startup. With the patched
+NCCL 2.30.4 it settles at **80KB** on the 4× PCIe topology (the old fixed
+crossover was 120KB with stock NCCL) — i.e. the patched NCCL wins back part of
+the mid-size allreduce range from the custom kernel.
 
 ### voipmonitor/vllm:cu130 (recommended for vLLM)
 
@@ -413,10 +534,27 @@ Or for newer vLLM versions:
 - **MTP=2 is the sweet spot** for nvidia NVFP4 on vLLM. Provides ~50-55% throughput improvement.
 - **MTP=5** works for short context but is **unstable at long context**. Crashes with illegal memory access.
 - **MTP>3** has a bug in vLLM causing crashes (PR #35615 partially fixes this).
-- MTP was **slower** than no-MTP on SGLang in early testing.
 - **CARVE model**: Do NOT use MTP since "MTP was trained on censored content" and the model is abliterated.
 - MTP can cause **tool call format changes** (XML instead of JSON) when `tool_choice='required'`. Fix: PR #35936.
 - `SGLANG_ENABLE_SPEC_V2=true` -- Required environment variable for SGLang spec decode v2.
+
+### SGLang MTP A/B on cu132 (June 2026, AWQ, EAGLE topk=1)
+
+Steps/draft tradeoff measured back-to-back on the production config
+(30 s per cell, ctx=0):
+
+| Config | c=1 tok/s | c=4 tok/s |
+|---|---|---|
+| steps=4, draft=5 | 240.1 | **631.7** |
+| steps=5, draft=6 | **253.1** (+5.4%) | 566.0 (−10.4%) |
+
+- **steps=4/draft=5 is the better default for mixed/agent traffic** — the
+  c=1 win of 5/6 costs ~10% at c=4, where deeper speculation wastes draft
+  work on rejected tokens (`spec_accept_length` ≈ 3.4 under load).
+- Pick steps=5/draft=6 only for a dedicated single-user box.
+- `--schedule-policy lpm` (longest-prefix-match) is recommended for agentic
+  workloads — agent loops resend large shared prefixes, and lpm maximizes
+  prefix-cache reuse. No downside observed at this scale.
 
 ### MTP acceptance rates (vLLM)
 
@@ -438,18 +576,114 @@ Or for newer vLLM versions:
 
 ---
 
-## YaRN Extended Context (up to 900K)
+## YaRN Extended Context
 
-To extend context beyond 262K (up to ~921K), use YaRN rope scaling with the CARVE model:
+### vLLM (works as documented)
+
+To extend context beyond 262K on vLLM, use the nested `--hf-overrides` form
+(unchanged from before; vLLM merges nested dicts into sub-configs):
 
 ```bash
 --hf-overrides '{"text_config": {"rope_parameters": {"mrope_interleaved": true, "mrope_section": [11, 11, 10], "rope_type": "yarn", "rope_theta": 10000000, "partial_rotary_factor": 0.25, "factor": 4.0, "original_max_position_embeddings": 262144}}}'
 ```
 
-- **factor: 4.0** extends to ~921K max context (4x the original 262K)
+- **factor: 4.0** extends to ~921K max context (4× the original 262K)
 - Requires `VLLM_ALLOW_LONG_MAX_MODEL_LEN=1` and `--max-model-len 921600`
 - Works with FP8 KV cache (`--kv-cache-dtype fp8`)
 - CARVE model performs **significantly better** at >300K with YaRN than the nvidia reference
+
+### SGLang: both CLI override forms are broken — use a patched checkpoint dir
+
+**Do not use `--json-model-override-args` for YaRN on Qwen3.5.** Verified
+June 2026 on the voipmonitor images and reproduced on upstream 0.5.12.post1:
+
+1. **The flat form is a SILENT NO-OP.**
+
+   ```bash
+   # looks right, does nothing:
+   --json-model-override-args '{"rope_scaling":{"rope_type":"yarn","factor":2.0,"original_max_position_embeddings":262144}}'
+   ```
+
+   Qwen3.5 checkpoints are VLM-format (`Qwen3_5MoeForConditionalGeneration`):
+   sglang applies the override to the **parent** config, but the language
+   model is built from `config.text_config`, whose `rope_parameters` stay
+   native. The server comes up healthy and serves >262K requests on
+   **unscaled native rope**. The only tell is this startup log line:
+
+   ```
+   User-specified context_length (524288) is greater than the derived context_length (262144)
+   ```
+
+2. **The nested form — the one the official Qwen model card documents for
+   SGLang — crashes on startup.**
+
+   ```bash
+   # from the Qwen3.5-397B-A17B model card; crashes:
+   --json-model-override-args '{"text_config":{"rope_parameters":{...}}}'
+   ```
+
+   sglang's flat `config.update()` replaces `text_config` with a plain dict →
+   `AssertionError` in `get_hf_text_config`. See sglang Discussion #26440;
+   an upstream issue draft covering both failure modes exists but is unfiled
+   as of 2026-06-11.
+
+**Working method — patch the checkpoint's `config.json`:** make a local model
+dir that symlinks every checkpoint file and carries one real, patched
+`config.json` (costs no disk; relative symlinks survive the container mount):
+
+```bash
+SNAP=~/.cache/huggingface/hub/models--QuantTrio--Qwen3.5-397B-A17B-AWQ/snapshots/<snapshot-hash>
+DEST=~/.cache/huggingface/local-models/qwen35-397b-awq-yarn524k
+mkdir -p "$DEST" && cd "$DEST"
+for f in "$SNAP"/*; do ln -s --relative "$f" .; done
+rm config.json && cp "$SNAP/config.json" config.json
+# then edit config.json as below
+```
+
+In `config.json`, set `text_config.rope_parameters` to **exactly** this
+(factor 2.0 → 524K; transformers replaces the whole dict, so **every key must
+be repeated** — and the `mrope_*` keys are mandatory or image position
+encoding breaks; the model is natively multimodal):
+
+```json
+"rope_parameters": {
+  "mrope_interleaved": true,
+  "mrope_section": [11, 11, 10],
+  "rope_type": "yarn",
+  "rope_theta": 10000000,
+  "partial_rotary_factor": 0.25,
+  "factor": 2.0,
+  "original_max_position_embeddings": 262144
+}
+```
+
+Then launch with `--model-path <patched dir>` plus:
+
+```bash
+-e SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN=1 \
+...
+--context-length 524288
+```
+
+Both are still required: sglang derives the native 262144 and does **not**
+multiply by the YaRN factor for v5 `rope_parameters`. That also means the
+"derived context_length (262144)" warning **persists under real YaRN** — on
+the patched-dir setup it is no longer a no-op indicator. Verify instead that
+rope dispatch went to `YaRNScalingMRotaryEmbedding` with a 524288-position
+cos/sin cache (visible with a one-off `get_config()`/`get_rope()` check
+inside the image).
+
+### Do you even need YaRN? (needle results, June 2026)
+
+Surprising finding from the months the silent no-op went unnoticed: **native
+rope passed needle retrieval 3/3 at 518K tokens** on this architecture — the
+3:1 GDN hybrid plus partial rotary (0.25) plus rope_theta 1e7 make
+over-extension degrade gracefully. The patched YaRN config also scored 3/3 at
+518K, 10/10 on a short-context battery, and passed a vision probe — i.e. no
+measurable YaRN penalty at short context, and spec-correct positions for the
+full window. Bottom line: YaRN matters for harder long-context *reasoning*,
+not basic retrieval; if you stay ≤262K, skip the patched dir entirely and run
+`--context-length 262144` (Qwen's own guidance).
 
 ---
 

--- a/models/qwen35-397b.md
+++ b/models/qwen35-397b.md
@@ -485,8 +485,8 @@ Pre-built image with all SM120 patches:
 > **Availability:** the `cu132` / `cu132-picks` tags are not yet published to
 > Docker Hub. Until voipmonitor publishes them, build locally from
 > [local-inference-lab/blackwell-llm-docker PR #1](https://github.com/local-inference-lab/blackwell-llm-docker/pull/1):
-> `Dockerfile.sglang-cu132-refresh` (full build incl. sgl-kernel, use
-> `build-guarded.sh`) then optionally `Dockerfile.sglang-cu132-picks` (the
+> `Dockerfile.sglang-cu132-refresh` (full build incl. sgl-kernel; keep
+> `KERNEL_MAX_JOBS` conservative) then optionally `Dockerfile.sglang-cu132-picks` (the
 > cherry-pick layer). All benchmark numbers in the June sections were produced
 > from these Dockerfiles.
 

--- a/models/qwen35-397b.md
+++ b/models/qwen35-397b.md
@@ -334,7 +334,7 @@ docker run --gpus '"device=0,1,2,3"' \
   -e SAFETENSORS_FAST_GPU=1 \
   -e OMP_NUM_THREADS=8 \
   -e SGLANG_ENABLE_SPEC_V2=true \
-  voipmonitor/sglang:cu132 \
+  voipmonitor/sglang:cu132 \  # build from blackwell-llm-docker#1 (not yet on Docker Hub)
   python3 -m sglang.launch_server \
     --model-path QuantTrio/Qwen3.5-397B-A17B-AWQ \
     --served-model-name Qwen3.5 \
@@ -460,7 +460,7 @@ command: >
 | Image | Purpose |
 |---|---|
 | **`voipmonitor/sglang:cu130`** | **Recommended.** SGLang with SM120 patches, FlashInfer from source (PR #2913 GDC), b12x 0.7.1 attention+MoE backend, PCIe allreduce, NCCL graph. PyTorch 2.11 cu130. |
-| **`voipmonitor/sglang:cu132`** | SGLang refresh (June 2026): CUDA 13.2.1, PyTorch 2.12.0+cu132 wheels, patched NCCL 2.30.4, cuBLAS 13.4.1/cuDNN 9.22, FlashInfer 0.6.12, **b12x 0.20.0**, fork @ `260194aa`. **Flag change:** `--enable-pcie-oneshot-allreduce-fusion` is gone — use `--pcie-oneshot-allreduce-max-size auto`. |
+| **`voipmonitor/sglang:cu132`** *(not yet on Docker Hub — build from [blackwell-llm-docker#1](https://github.com/local-inference-lab/blackwell-llm-docker/pull/1))* | SGLang refresh (June 2026): CUDA 13.2.1, PyTorch 2.12.0+cu132 wheels, patched NCCL 2.30.4, cuBLAS 13.4.1/cuDNN 9.22, FlashInfer 0.6.12, **b12x 0.20.0**, fork @ `260194aa`. **Flag change:** `--enable-pcie-oneshot-allreduce-fusion` is gone — use `--pcie-oneshot-allreduce-max-size auto`. |
 | **`voipmonitor/vllm:cu130`** | **Recommended.** vLLM with SM120 patches, FlashInfer from source, cherry-picked PRs (#35675, #35936, #37132). |
 | `lmsysorg/sglang:dev-cu13` | Official SGLang nightly for CUDA 13. May need `pip install transformers>=5.3,<5.4`. |
 | `vllm/vllm-openai:cu130-nightly` | Official vLLM nightly for CUDA 13 |
@@ -479,6 +479,14 @@ Pre-built image with all SM120 patches:
 - sgl-kernel built from source
 
 ### voipmonitor/sglang:cu132 (June 2026 refresh)
+
+> **Availability:** the `cu132` / `cu132-picks` tags are not yet published to
+> Docker Hub. Until voipmonitor publishes them, build locally from
+> [local-inference-lab/blackwell-llm-docker PR #1](https://github.com/local-inference-lab/blackwell-llm-docker/pull/1):
+> `Dockerfile.sglang-cu132-refresh` (full build incl. sgl-kernel, use
+> `build-guarded.sh`) then optionally `Dockerfile.sglang-cu132-picks` (the
+> cherry-pick layer). All benchmark numbers in the June sections were produced
+> from these Dockerfiles.
 
 Refreshed stack matching driver 595.71+ (CUDA 13.2). Same April fork tree as
 cu130 (the June upstream CUDA-graph/attention refactor would require a full

--- a/models/qwen35-397b.md
+++ b/models/qwen35-397b.md
@@ -324,6 +324,8 @@ docker run --gpus '"device=0,1,2,3"' \
 
 ### AWQ-INT4 on cu132-picks, 4x GPUs, EAGLE 4/5 + lpm (259 tok/s c=1 / 1226 tok/s c=16)
 
+_Image not yet on Docker Hub — build from [blackwell-llm-docker#1](https://github.com/local-inference-lab/blackwell-llm-docker/pull/1) first._
+
 ```bash
 docker run --gpus '"device=0,1,2,3"' \
   --ipc=host --shm-size=8g --network=host \
@@ -334,7 +336,7 @@ docker run --gpus '"device=0,1,2,3"' \
   -e SAFETENSORS_FAST_GPU=1 \
   -e OMP_NUM_THREADS=8 \
   -e SGLANG_ENABLE_SPEC_V2=true \
-  voipmonitor/sglang:cu132 \  # build from blackwell-llm-docker#1 (not yet on Docker Hub)
+  voipmonitor/sglang:cu132 \
   python3 -m sglang.launch_server \
     --model-path QuantTrio/Qwen3.5-397B-A17B-AWQ \
     --served-model-name Qwen3.5 \

--- a/models/qwen35-397b.md
+++ b/models/qwen35-397b.md
@@ -485,7 +485,7 @@ Pre-built image with all SM120 patches:
 > **Availability:** the `cu132` / `cu132-picks` tags are not yet published to
 > Docker Hub. Until voipmonitor publishes them, build locally from
 > [local-inference-lab/blackwell-llm-docker PR #1](https://github.com/local-inference-lab/blackwell-llm-docker/pull/1):
-> `Dockerfile.sglang-cu132-refresh` (full build incl. sgl-kernel; keep
+> `Dockerfile.sglang-cu132` (full build incl. sgl-kernel; keep
 > `KERNEL_MAX_JOBS` conservative) then optionally `Dockerfile.sglang-cu132-picks` (the
 > cherry-pick layer). All benchmark numbers in the June sections were produced
 > from these Dockerfiles.

--- a/models/qwen35-397b.md
+++ b/models/qwen35-397b.md
@@ -2,8 +2,10 @@
 
 ## Quick Start
 
-**180 tok/s** single user with MTP, **108 tok/s** without MTP, **1550 tok/s** at 64 concurrent users.
-Runs on **4× RTX PRO 6000** (96 GB each) using NVFP4 quantization.
+**259 tok/s** single user (AWQ + b12x decode + EAGLE MTP, June 2026 cu132-picks image),
+**180 tok/s** NVFP4 + MTP (April), **1550 tok/s** at 64 concurrent users (no MTP).
+Runs on **4× RTX PRO 6000** (96 GB each); AWQ INT4 is now both the best-quality
+AND fastest single-stream quantization on the cu132-picks stack.
 
 ```bash
 docker pull voipmonitor/sglang:cu130
@@ -79,13 +81,14 @@ ctx\conc     1      2      4      8     16     32      64   128
 
 | Scenario | Setup | tok/s |
 |----------|-------|-------|
-| Single user, max speed | SGLang b12x + MTP | **180** |
+| Single user, max speed | AWQ + SGLang b12x decode + EAGLE MTP (cu132-picks, June 2026) | **259** |
+| Single user, NVFP4 (April) | SGLang b12x + MTP | 180 |
 | Single user, no MTP | SGLang b12x + PCIe oneshot | **108** |
 | Multi-user (c=32) | SGLang b12x, no MTP | **1174** |
 | Multi-user (c=64) | SGLang b12x, no MTP | **1551** |
 | High concurrency (c=128) | vLLM | **2277** |
 
-### AWQ + MTP, cu130 vs cu132 (June 2026, same host, same flags)
+### AWQ + MTP, cu130 vs cu132 (June 2026, same host, same flags) — malaiwah, aibeast
 
 `QuantTrio/Qwen3.5-397B-A17B-AWQ`, TP=4, EAGLE steps=4/draft=5,
 `--prefill-attention-backend flashinfer --decode-attention-backend b12x
@@ -114,6 +117,23 @@ rework); concurrency gains come from b12x 0.20 and the crossover fix. On the
 final production config (YaRN-524K patched checkpoint + `--schedule-policy
 lpm`, steps=4/draft=5), cu132 measured **240.1 c=1 / 631.7 c=4** at ctx=0 —
 within 2% of cu130 single-stream with everything else better.
+
+**`voipmonitor/sglang:cu132-picks` final (kernel build: + sgl-kernel case-512
+router kernel #25775, EAGLE topk-1 fastpaths #26397/#26424, chunked-prefill
+draft-chain fix #26800, leak/crash fixes; YaRN-524K + lpm config):**
+
+```
+ctx\conc      1      4
+   0      259.5  638.5
+  16k     244.3  602.9
+```
+
+Day total at c=1 ctx=0: **244.3 → 259.5 (+6.2%)** vs the cu130 morning
+baseline. The case-512 router kernel alone was worth +7.7% c=1 over the
+python-only pick layer (240.9 → 259.5) — bs=1 decode is launch-latency-bound,
+so ~8 µs saved on `topk_softmax` at every MoE layer per step adds up.
+Spec accept-length under load: 3.46 → ~3.6-3.7 (the #26800 draft-chain fix;
+gains concentrate on multi-chunk prompts >16K tokens).
 
 > These are AWQ numbers with the b12x decode backend — not directly comparable
 > to the April AWQ row (152 tok/s), which predates
@@ -302,7 +322,7 @@ docker run --gpus '"device=0,1,2,3"' \
 
 > **AWQ note:** SGLang auto-detects AWQ quantization from the config — do NOT add `--quantization`. The `--mamba-scheduler-strategy extra_buffer` flag is required because AWQ uses VLM format (`Qwen3_5MoeForConditionalGeneration`).
 
-### AWQ-INT4 on cu132, 4x GPUs, EAGLE 4/5 + lpm (240 tok/s c=1 / 1226 tok/s c=16)
+### AWQ-INT4 on cu132-picks, 4x GPUs, EAGLE 4/5 + lpm (259 tok/s c=1 / 1226 tok/s c=16)
 
 ```bash
 docker run --gpus '"device=0,1,2,3"' \
@@ -785,8 +805,10 @@ ctx\conc     1      2      4      8     16     32      64      128
 
 | Config | Engine | MTP | tok/s |
 |--------|--------|-----|-------|
-| **NVFP4** | **SGLang b12x + PCIe oneshot** | **MTP** | **180** |
-| AWQ INT4 | SGLang + PCIe oneshot | MTP=5 | 152 |
+| **AWQ INT4** | **SGLang b12x decode, cu132-picks (June 2026, malaiwah)** | **EAGLE 4/5** | **259** |
+| AWQ INT4 | SGLang b12x decode, cu132 (June 2026) | EAGLE 4/5 | 240 |
+| NVFP4 | SGLang b12x + PCIe oneshot (April) | MTP | 180 |
+| AWQ INT4 | SGLang + PCIe oneshot (April, pre-b12x-decode) | MTP=5 | 152 |
 | NVFP4 | vLLM | MTP=2 | 130 |
 | NVFP4 | SGLang b12x + PCIe oneshot | No | 108 |
 | NVFP4 | SGLang cutlass + PCIe oneshot | No | 76 |


### PR DESCRIPTION
Updates models/qwen35-397b.md with June 2026 production findings from the aibeast 4x RTX PRO 6000 Workstation deployment:

- **New image**: voipmonitor/sglang:cu132 (CUDA 13.2.1, torch 2.12.0+cu132 wheels, patched NCCL 2.30.4, b12x 0.20.0) + the cu132-picks cherry-pick layer (incl. a port of open sgl-project/sglang#25881 — /v1/responses function-tool support, validated live with Hermes Agent).
- **June benchmarks** (AWQ + EAGLE MTP, cu130 vs cu132), kept separate from the April tables with a comparability caveat.
- **YaRN section corrected**: SGLang's --json-model-override-args rope_scaling is a silent no-op for Qwen3.5 (VLM-format text_config), the model-card nested form crashes, and the working patched-checkpoint-dir method is documented with the exact rope_parameters JSON. Includes the 518K-token native-rope needle results.
- **MTP A/B data** (steps 4/5 vs 5/6) and the schedule-policy lpm recommendation for agentic workloads.
- Fixed the Dockerfiles repo link (voipmonitor -> local-inference-lab).

Source/Dockerfiles PR: local-inference-lab/blackwell-llm-docker (cu132-refresh-and-fixes branch).