### PR TITLE
Add DS4-Flash DSpark true 4-bit (NVFP4) KV cache page

### DIFF
--- a/INDEX.md
+++ b/INDEX.md
@@ -51,6 +51,7 @@ python3 scripts/generate-wiki-index.py > INDEX.md
 - [DeepSeek-V4-Flash-0731 Infernal Invocation r7](models/ds4dspark-infernal-invocation-r7.md) - `models/ds4dspark-infernal-invocation-r7.md`
 - [DeepSeek-V4-Flash-0731 Infernal Invocation r9](models/ds4dspark-infernal-invocation-r9.md) - `models/ds4dspark-infernal-invocation-r9.md`
 - [DeepSeek-V4-Flash-0731 Jovian Judgement r1](models/ds4dspark-jovian-judgement-r1.md) - `models/ds4dspark-jovian-judgement-r1.md`
+- [DeepSeek-V4-Flash DSpark — True 4-bit (NVFP4) KV Cache on 2× GPUs](models/ds4dspark-nvfp4-kv.md) - `models/ds4dspark-nvfp4-kv.md`
 - [DeepSeek-V4-Flash and DSpark v10](models/ds4dspark-v10.md) - `models/ds4dspark-v10.md`
 - [DeepSeek-V4-Flash-0731 DSpark on Gilded Gnosis r15](models/ds4dspark-v20-r15.md) - `models/ds4dspark-v20-r15.md`
 - [DeepSeek-V4-Flash-0731 DSpark: Gilded Gnosis r16](models/ds4dspark-v20-r16.md) - `models/ds4dspark-v20-r16.md`
@@ -98,7 +99,6 @@ python3 scripts/generate-wiki-index.py > INDEX.md
 - [GLM-5.1 v8 DCP Graph Fix on 8x RTX PRO 6000 Blackwell](models/glm5.1_v8.md) - `models/glm5.1_v8.md`
 - [GLM-5.1 v9 BF16 TP16 DCP8 on 16x RTX PRO 6000 Blackwell](models/glm5.1_v9.md) - `models/glm5.1_v9.md`
 - [CUTLASS DSL 4.6 SM120 W4A16 Prefill Regression](models/glm5.2/cutlass-dsl-46-w4a16-regression-2026-07-18.md) - `models/glm5.2/cutlass-dsl-46-w4a16-regression-2026-07-18.md`
-- [GLM-5.2 BF16 to EXL3-TR3 3.0 bpw: Calibrated-LDLQ Conversion Recipe (incl. MTP layer 78)](models/glm5.2/glm52-exl3-tr3-quantization-2026-07-26.md) - `models/glm5.2/glm52-exl3-tr3-quantization-2026-07-26.md`
 - [GLM-5.2 GGUF to BF16 Dequant KLD Audit](models/glm5.2/glm52-gguf-bf16-dequant-kld-2026-07-08.md) - `models/glm5.2/glm52-gguf-bf16-dequant-kld-2026-07-08.md`
 - [GLM-5.2 Unsloth-Style Prefill KLD Reproduction](models/glm5.2/glm52-unsloth-style-prefill-kld-2026-07-07.md) - `models/glm5.2/glm52-unsloth-style-prefill-kld-2026-07-07.md`
 - [GLM-5.2 Infernal Invocation r11](models/glm5.2-infernal-invocation-r11.md) - `models/glm5.2-infernal-invocation-r11.md`

--- a/models/deepseek-v4-flash.md
+++ b/models/deepseek-v4-flash.md
@@ -17,6 +17,7 @@ specifications.
 | Inspect the Gilded Gnosis baseline | [DeepSeek-V4-Flash-0731 Gilded Gnosis r33](ds4dspark-v20-r33.md) |
 | Inspect the Fathomless TP2/TP4 sweep | [DeepSeek-V4-Flash v10 Fathomless Validation](ds4dspark-v10.md) |
 | Inspect the full DSpark and standard-MTP sweep | [DeepSeek-V4-Flash and DSpark v9](ds4dspark-v9.md) |
+| Need more KV cache headroom / longer context on DSpark | [DS4 DSpark NVFP4-KV](ds4dspark-nvfp4-kv.md) |
 | Diagnose empty reasoning before tool calls | [DS4 empty-think troubleshooting](ds4f-empty-think/README.md) |
 
 ## Serving Contracts

--- a/models/ds4dspark-nvfp4-kv.md
+++ b/models/ds4dspark-nvfp4-kv.md
@@ -1,0 +1,165 @@
+# DeepSeek-V4-Flash DSpark — True 4-bit (NVFP4) KV Cache on 2× GPUs
+
+True 4-bit E2M1 KV cache (`--kv-cache-dtype nvfp4_ds_mla`) for DeepSeek-V4-Flash
+sparse-MLA on 2× RTX PRO 6000 (SM120), on top of the DSpark stack. Compared to
+`fp8_ds_mla` on the same build: **1.47× more KV tokens per GiB, +25–34% decode**,
+and start-position needle recall verified past **1M real tokens**. The fp8 path
+is byte-identical and re-validated green on the same build (nvfp4 is a strict
+addition).
+
+Prior context: an earlier true-4-bit attempt in the DSpark line corrupted output
+beyond ~411 prompt tokens. Root cause was page geometry — the GLM 512-wide layout
+applied to DeepSeek-V4's 448-wide NoPE. This port implements the DSV4-native
+layout instead, and reuses the fp8 tensor-core math path unchanged (every E2M1
+magnitude is exactly representable in e4m3, so kernels expand nibbles in-place
+and the existing block-scaled MMA + UE8M0 scales reproduce values losslessly).
+
+## Table of Contents
+
+- [Docker Image](#docker-image)
+- [What's In The Patch Series](#whats-in-the-patch-series)
+- [KV Page Layout](#kv-page-layout)
+- [Launch Command — Standing Config (262K)](#launch-command--standing-config-262k)
+- [Launch Command — 1M Context](#launch-command--1m-context)
+- [Benchmarks](#benchmarks)
+- [Quality](#quality)
+- [Known Issues & Tips](#known-issues--tips)
+- [Source & Credits](#source--credits)
+
+---
+
+## Docker Image
+
+```text
+danielwoz/vllm:dspark-nvfp4-cu132-20260708
+danielwoz/vllm@sha256:4fc2e9ef3d0a489b892f330484078090d8c77125f292b21c560df649da7238eb
+```
+
+Built on the DSpark image with the patch series applied and the sparse-MLA
+kernel recompiled into the AOT slot (no JIT at startup). The full series,
+Dockerfile, and validation harnesses ship in the image at `/opt/nvfp4/` and at
+the source repo below.
+
+| Component | Pin |
+|---|---|
+| Base image | `fraserpricee/vllm:dspark-cu132-20260627` |
+| FlashInfer | `0.6.13+cu132` (base image) + `01-flashinfer-cuda` series |
+| vLLM | DSpark fork from base image + `03-vllm-nvfp4` series |
+| Patch series | `https://github.com/danielwoz/vllm-dspark-nvfp4` @ `c633834` |
+| CUDA | 13.2 runtime, arch `12.0f` |
+
+## What's In The Patch Series
+
+- `01-flashinfer-cuda/` — `ModelType::DSV4_NVFP4` + KV-cache traits, packed-byte
+  TMA IO (byte-identical fp8 `arrive.expect_tx` protocol; fp8 is the offset-0
+  case of the same path), in-place E2M1→fp8-e4m3 nibble expand in the decode and
+  prefill consumers. ~180 lines.
+- `02-flashinfer-python/` — dispatch gates, `kv_scale_format="nvfp4"`, page-size
+  asserts relaxed to `{584, 360}`.
+- `03-vllm-nvfp4/` — `nvfp4_ds_mla` dtype registration and plumbing, two Triton
+  store kernels (SWA store + compressed-cache variant), a standalone q-transform
+  Triton kernel (bit-exact vs the fused fp8 C++ op, difftest included), plus two
+  standalone bugfixes that also apply to fp8 (`compressor.py` missing
+  `cache_dtype_str`/`model_version` on `SlidingWindowMLASpec`; `sparse_swa.py`
+  `get_kv_cache_shape` missing dtype branch).
+
+## KV Page Layout
+
+360 B/token (fp8_ds_mla is 584), mirroring the fp8 footer structure:
+
+```text
+data slot (stride 352): [0:224) 448× E2M1 nibbles (2/byte) | [224:352) 64× bf16 RoPE
+footer @ pbs*352 + t*8: 7× per-64 UE8M0 scale + 1 pad     (footer identical to fp8)
+scale: per-64 UE8M0 chosen so max|v| / 2^(e-127) ≤ 6.0 (E2M1 max), RTN via hardware cvt
+```
+
+## Launch Command — Standing Config (262K)
+
+DSpark spec-decode + full cudagraphs. Note `--gpu-memory-utilization 0.96+`:
+0.90 leaves too little KV headroom after graph capture with DSpark.
+
+```bash
+docker run --gpus '"device=0,1"' --ipc=host -p 8000:8000 \
+  -v /path/to/hf-cache:/hf -e HF_HOME=/hf \
+  danielwoz/vllm:dspark-nvfp4-cu132-20260708 \
+    fraserprice/DeepSeek-V4-Flash-Abliterated-DSpark \
+    --tensor-parallel-size 2 --kv-cache-dtype nvfp4_ds_mla --block-size 256 \
+    --tokenizer-mode deepseek_v4 --trust-remote-code \
+    --speculative-config '{"method":"dspark","num_speculative_tokens":4,"draft_sample_method":"probabilistic"}' \
+    --attention-backend FLASHINFER_MLA_SPARSE_DSV4 --kernel-config.moe_backend=marlin \
+    --max-model-len 262144 --gpu-memory-utilization 0.96 \
+    --max-num-seqs 32 --max-num-batched-tokens 2048 \
+    --disable-custom-all-reduce --async-scheduling \
+    --enable-chunked-prefill --enable-prefix-caching \
+    --max-cudagraph-capture-size 64 \
+    --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"]}' \
+    --reasoning-parser deepseek_v4 --enable-auto-tool-choice --tool-call-parser deepseek_v4
+```
+
+Memory info (2× RTX PRO 6000, TP2):
+
+```text
+GPU KV cache size: 1,539,217 tokens
+Maximum concurrency for 262,144 tokens per request: 5.87x
+```
+
+## Launch Command — 1M Context
+
+Same stack with `--max-model-len 1048576 --enforce-eager` (cudagraphs off buys
+the KV headroom) and `--gpu-memory-utilization 0.96`:
+
+```text
+GPU KV cache size: 2,935,863 tokens
+```
+
+Needle at position zero recalled at **1,030,039 real prompt tokens**.
+
+## Benchmarks
+
+Same build, same config, fp8 vs nvfp4 A/B (TP2, DSpark, cudagraphs, util 0.96,
+262K max-len):
+
+| Metric | fp8_ds_mla | nvfp4_ds_mla |
+|---|---|---|
+| KV footprint | 15.3 KB/token | **10.4 KB/token (1.47×)** |
+| KV pool (same run config) | 591,951 tokens | 601,457 tokens |
+| KV pool (tuned standing config) | — | **1,539,217 tokens** |
+| Decode (DSpark accepted) | ~195 tok/s | **243–262 tok/s (+25–34%)** |
+| DSpark acceptance | 3.55 / 4 | 3.67 / 4 |
+
+Decode gain tracks the KV byte reduction — sparse-MLA decode gathers are
+bandwidth-bound, and nvfp4 moves 1.6× fewer KV bytes.
+
+## Quality
+
+| Test | fp8 reference | nvfp4 |
+|---|---|---|
+| HumanEval-164 | 85.0% | **90.2%** |
+| MBPP-100 | — | **94%** |
+| Needle/garble sweep (100..8000 real toks) | all green | **all green** |
+| Start-position needle @1,030,039 real toks | — | **recalled** |
+| fp8 regression on the nvfp4 build | all green (zero-diff) | — |
+
+Harnesses (`kvtest.py`, `qualbench.py`, `ctxbench.py`) ship in the image at
+`/opt/nvfp4/validation/` and in the source repo.
+
+## Known Issues & Tips
+
+- **SM120 only.** The kernels are `sparse_mla_sm120`; nothing else is compiled.
+- **util 0.90 fails with DSpark + cudagraphs** (KV squeeze after capture) — use
+  0.96–0.985.
+- **vLLM memory profile shows ~2.6 GiB more non-KV overhead vs fp8** (Triton
+  JIT of the new store kernels + profiling-pass activation peak) — accounted
+  for, not a leak.
+- fp8 checkpoints/behavior are untouched: `--kv-cache-dtype fp8_ds_mla` on this
+  image behaves exactly like the base image.
+
+## Source & Credits
+
+- Patch series + Dockerfile + validation: <https://github.com/danielwoz/vllm-dspark-nvfp4>
+- Image: `danielwoz/vllm:dspark-nvfp4-cu132` (floating) / `:dspark-nvfp4-cu132-20260708`
+- Built directly on tonyd2wild's DSpark stack and fraserpricee's image — the
+  packed-KV IO protocol, spec-decode, and serving stack are theirs; this series
+  adds the DSV4-native 4-bit page layout, the expand path, and the vLLM plumbing.
+- vLLM and FlashInfer are Apache-2.0; full diffs vs the pristine base ship in
+  the image under `/opt/nvfp4/patches/`.

--- a/models/ds4dspark-nvfp4-kv.md
+++ b/models/ds4dspark-nvfp4-kv.md
@@ -128,7 +128,7 @@ Same build, same config, fp8 vs nvfp4 A/B (TP2, DSpark, cudagraphs, util 0.96,
 | DSpark acceptance | 3.55 / 4 | 3.67 / 4 |
 
 Decode gain tracks the KV byte reduction — sparse-MLA decode gathers are
-bandwidth-bound, and nvfp4 moves 1.6× fewer KV bytes.
+bandwidth-bound, and nvfp4 moves 1.47× fewer KV bytes.
 
 ## Quality
 

--- a/optimization/nvfp4-quantization.md
+++ b/optimization/nvfp4-quantization.md
@@ -196,6 +196,14 @@ Checkpoints without calibrated KV scales default to BF16 KV cache:
 
 **Kimi K2.5 (SGLang):** FP8 KV on the original INT4 checkpoint drops to 16 tok/s. The NVFP4 checkpoint supports FP8 KV at 55 tok/s.
 
+### True 4-bit KV Cache (nvfp4_ds_mla) — DeepSeek-V4-Flash DSpark
+
+DeepSeek-V4-Flash sparse-MLA on 2× GPUs supports a true 4-bit E2M1 KV cache via
+a community patch series on the DSpark stack: 1.47× more KV tokens per GiB than
+fp8_ds_mla, +25–34% decode (bandwidth-bound gathers move fewer bytes), needle
+recall verified past 1M real tokens, and a zero-diff fp8 path on the same build.
+See [DS4-Flash DSpark NVFP4-KV](../models/ds4dspark-nvfp4-kv.md).
+
 ---
 
 ## CARVE: Unlocked/Abliterated Models


### PR DESCRIPTION
This documents a working true 4-bit (E2M1) KV cache for DeepSeek-V4-Flash
sparse-MLA on 2x RTX PRO 6000, on the DSpark stack. The wiki mentions the
earlier 4-bit KV attempt that corrupted past ~411 prompt tokens — that turned
out to be page geometry (the GLM 512-wide layout applied to DSV4's 448-wide
NoPE) rather than a dead end. With a DSV4-native 360 B/token layout it works:
1.47x more KV tokens per GiB than fp8_ds_mla, decode up from ~195 to 243-262
tok/s (the gathers are bandwidth-bound), and needle recall still good at just
over 1M real prompt tokens. fp8 on the same build re-tested green, so it's a
strict addition.

The page has launch commands for a 262K standing config and a 1M config, an
fp8 vs nvfp4 A/B, quality numbers (HumanEval/MBPP), and component pins. The
patch series, Dockerfile and test harnesses are at
github.com/danielwoz/vllm-dspark-nvfp4, and there's a prebuilt image
(danielwoz/vllm:dspark-nvfp4-cu132) on top of fraserpricee's dspark image.
I also added a row to the README model table and a short note in the NVFP4
optimization page's KV cache section.

Happy to fold this into the ds4dspark v-series numbering instead of a
standalone page if that's preferred.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive runbook for DeepSeek-V4-Flash DSpark with true 4-bit NVFP4 KV cache support on two GPUs.
  * Documented setup, launch configurations, validation results, performance comparisons, page layout, known issues, and troubleshooting guidance.
  * Added NVFP4 KV cache guidance to optimization and DeepSeek-V4-Flash documentation.
  * Updated the documentation index with the new runbook and daily summary entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->