### PR TITLE
models/glm5.2: EXL3-TR3 3.0bpw calibrated-LDLQ conversion recipe (incl. MTP layer 78)

### DIFF
--- a/models/glm5.2/glm52-exl3-tr3-quantization-2026-07-26.md
+++ b/models/glm5.2/glm52-exl3-tr3-quantization-2026-07-26.md
@@ -1,0 +1,413 @@
+# GLM-5.2 BF16 to EXL3-TR3 3.0 bpw: Calibrated-LDLQ Conversion Recipe (incl. MTP layer 78)
+
+Documented 2026-07-26. Base encode performed 2026-07-20 on an 8x B300 node
+(SM 10.3 GPUs; quantizer ops built for arch 10.0); the MTP layer-78 leg validated 2026-07-24/25 on 4x RTX PRO 6000 Blackwell.
+
+This page documents the full conversion recipe behind
+[`brandonmusic/GLM-5.2-EXL3-TR3-3.0bpw`](https://huggingface.co/brandonmusic/GLM-5.2-EXL3-TR3-3.0bpw):
+GLM-5.2 753B BF16 routed MoE experts to a 3.0-bpw EXL3 **Trellis**
+representation via a **calibrated LDLQ** pass, TP4 rank-sliced, MCG codebook.
+
+**This recipe deliberately differs from the checkpoint's own
+`calibration_encoder/README.md` in one place: the MTP draft layer (78) routed
+experts are trellis-encoded with the identical calibrated-LDLQ math as layers
+3..77** — from a serving-time capture, because the draft layer never executes
+in the offline prefill pass — instead of being carried BF16 and swapped in
+afterwards. The published checkpoint
+originally shipped with a BF16 MTP head; the trellis MTP-78 head was produced
+with the same encoder + corpus, validated at BF16 acceptance parity, and
+grafted on later (checkpoint commit `41a1c8ae`). This page folds that step
+into the pipeline where it belongs, with patches against the published
+scripts. Nothing else in the recipe is changed.
+
+Lower KLD is better; higher acceptance length is better.
+
+## Artifact summary
+
+| Field | Value |
+|---|---|
+| Base model | [`zai-org/GLM-5.2`](https://huggingface.co/zai-org/GLM-5.2) (BF16, 78 layers + MTP, 256 routed experts/layer) |
+| Quantized | routed MoE expert `gate_proj`/`up_proj`/`down_proj`, all 256 experts, **layers 3..78 (incl. MTP layer 78)** |
+| Kept BF16 (byte-exact) | attention, dense MLPs (layers 0..2), shared experts, router/gates, embeddings, `lm_head`, layer-78 non-expert tensors (`eh_proj`, `enorm`, `hnorm`, `shared_head.norm`) |
+| Format | EXL3 Trellis, 3.0 bpw, MCG codebook (`0xCBAC1FED`), TP4 rank-sliced (`.rank{0..3}.{trellis,suh,svh,mcg}`) |
+| Hessians | calibrated LDLQ (`finalize_capture_H` -> block LDL -> blocked LDLQ with error feedback), exllamav3 0.0.43 reference math |
+| Calibration corpus | `reap_recall_calib.jsonl`, 12,228 rows, 4 axes, SHA-256 `cf247acc7c5da9f0600c7d6ab3b7c2fcfc54ec30b794e3b6047559285fa44df4` |
+| Capture (layers 3..77) | offline prefill capture, 1,050,468 tokens/layer, natural top-8 routing |
+| Capture (layer 78) | live-serving capture with MTP enabled, 7,288,310 tokens (full corpus) |
+| Checkpoint size | `total_size` 316,304,795,648 bytes (tr3 MTP-78 head; 15,662,567,424 bytes smaller than the BF16-head variant) |
+| Encoder | `encode_tr3_v31.py` (SHA-256 `e9a85a47e165c8d8644354cef611efbb81dfd9ba88544ca59f0c80ee6bc75032`) + `encode_b300.py` adapter; patched per this page for layer 78 |
+
+The `quant_method: modelopt` field in the emitted `config.json` is a
+loader-dispatch shim only — the artifact contains zero NVFP4 expert payloads.
+
+## Why quantize the MTP head too
+
+The MTP layer is a full MoE decoder layer (256 experts, same shapes as layers
+3..77). Carried BF16 it costs ~19.3 GB on disk and ~4.8 GB/GPU at TP4 —
+VRAM that comes straight out of KV cache. Measured on 4x RTX PRO 6000
+Blackwell (TP4/DCP4, MTP-3; decode rows from the checkpoint's published
+RELEASE_TEST_SUITE A/B):
+
+| Metric | BF16 MTP head | Trellis 3.0-bpw MTP head |
+|---|---|---|
+| Draft weights VRAM (TP4) | ~4.8 GB/GPU | ~0.95 GB/GPU |
+| Mean acceptance length (identical 20-prompt greedy bench, 300 tok/req) | 3.054 (n=57 windows) | 3.06 (n=30 windows) — parity |
+| GPU KV capacity @ util 0.96, auto-profile | ~680K tokens | **1,132,544 tokens (~ +66%)** |
+| Decode C1/C4/C8 (auto-profiled KV, util 0.96, `VLLM_EXL3_TRELLIS_MIN_M=1`) | 87.5 / 219.3 / 308.1 t/s | 89.7 / 225.3 / 293.5 t/s (~neutral) |
+| Long-context + doc-generation checks | pass | pass (Estonia 10/10, lavd 5E/5N/0F) |
+
+Prompt-logit KLD of the target model is unchanged by construction: layer 78
+never executes in the target forward pass (it is the speculative draft), and
+MTP acceptance is lossless — rejected drafts are recomputed by the target.
+The base artifact's measured KLD vs BF16 reference logits (WikiText-2, one
+2048-token window, 5 fresh-boot runs) is 0.100-0.102 (mean 0.1012) with fp8 KV cache and 0.116-0.117 (mean
+0.1161) with nvfp4 KV cache; those numbers apply to this checkpoint
+unchanged.
+
+## Pipeline overview
+
+```
+                 zai-org/GLM-5.2 (BF16, 282 shards)
+                              |
+   [A] offline prefill capture, layers 3..77
+       capture_b300.py (vLLM TP8, enforce_eager; each window's layers striped
+       across the 8 ranks, one owner rank per layer; >=1,048,576 tok/layer;
+       <=8-layer windows in /dev/shm)
+                              |
+   [B] MTP layer-78 capture — one of:
+       (a) the published capture dataset (malaiwah/GLM-5.2-MTP78-calibration-
+           capture): reconstruct x.bin/ids.bin, no serving stack needed; or
+       (b) serve an MTP-capable GLM-5.2 deployment (reference: the as-shipped
+           tr3 checkpoint, BF16 draft head) with the mtp78_xcapture.py plugin
+           armed, and drive the corpus once (7,288,310 tokens)
+                              |
+       ./convert_b300.sh mtp78-import
+       (finalize_mtp78_capture.py: audits the payload, corpus-pinned
+       fingerprint, writes layer_078/layer_manifest.json)
+                              |
+   [C] calibrated LDLQ / trellis encode, per <=8-layer window, now incl. LAYERS=78
+       encode_b300.py --encode  ->  encode_tr3_v31.py (v3.1 lockstep, 8 workers x 8 GPUs)
+                              |
+   [D] ./convert_b300.sh assemble
+       merged shards (layer 78 = 23 BF16 non-expert + 12,288 trellis tensors),
+       config.json (hybrid_tr3_tail.moe_layers [3,78], ignore model.layers.78.eh_proj*),
+       tier_bitmap.json (incl. "78"), calibration_manifest.json, MANIFEST.sha256
+```
+
+Stages A, C, D are the published pipeline unchanged except for the layer-78
+scope; stage B and the import step are the addition. Note the loop stage B
+closes: a serving capture needs an MTP-capable deployment, and the patched
+one-pass build's own output does not exist yet at that point (the patched
+assembly hard-requires layer 78). A from-scratch run therefore either
+(a) imports the published capture dataset — the layer-78 leg becomes pure
+compute — or (b) captures on an independent deployment; the reference capture
+served the as-shipped tr3 checkpoint (quantized layers 3..77 + BF16 draft
+head), so the captured hidden states match the deployed target stack. The
+shipped `-MTP78` artifact took route (b) plus the graft; these patches fold
+the same capture into one encode+assemble pass.
+
+## Requirements
+
+- **exllamav3 == 0.0.43** with its source package installed. The six quantizer
+  ops (`had_r_128`, `pack_trellis`, `quantize_tiles`, `reconstruct`,
+  `reconstruct_slice`, `unpack_trellis`) are built from its sources as an
+  `sm_100` extension by `bootstrap_ext_b300.py`; the exllamav3 Python package
+  is never imported at runtime. The bootstrap refuses any other version.
+- NVIDIA Blackwell GPUs. Reference run: 8x B300 (SM 10.3 GPUs; quantizer ops
+  built for arch 10.0, `TORCH_CUDA_ARCH_LIST=10.0`), capture at TP8, tensors
+  packed for TP4. CUDA 12.9.
+- The BF16 base `zai-org/GLM-5.2` (~1.51 TB), large tmpfs for capture windows,
+  ~0.5 TB scratch for assembly. The orchestrator enforces disk/RAM guards.
+- For stage B route (b) only: an MTP-capable serving deployment of GLM-5.2
+  (the reference used a vLLM RC2-lineage image on 4x RTX PRO 6000, serving
+  the as-shipped tr3 checkpoint; the capture plugin is backend-agnostic at
+  the router level). Route (a) — the published capture dataset — needs no
+  serving stack at all.
+
+### exllamav3 version note (0.0.43 vs 1.x)
+
+This pipeline pins **exllamav3 0.0.43** (released 2026-06-14). Upstream has
+since moved to **1.x** — 1.0.0 (2026-07-14) changed the **default trellis
+codebook from MCG to MUL1**; 1.2.0 is current at the time of writing. The
+LDLQ quantization math this pipeline vendors is unchanged between 0.0.43 and
+1.x, but the codebook default is not:
+
+- This artifact (and its serving kernels) use **MCG `0xCBAC1FED`** tensors.
+- Byte-for-byte reproduction of this checkpoint **requires 0.0.43** — the
+  version guards in `bootstrap_ext_b300.py` / `encode_b300.py` are there on
+  purpose.
+- Porting the pipeline to 1.x should be possible (pin the codebook to MCG
+  explicitly), but produces an unverified variant and is out of scope here.
+
+## Calibration corpus
+
+JSONL, one object per line, 12,228 rows balanced across four axes
+(~3,057 each): `axis1_general`, `axis2_legal`, `axis3_code_agentic`,
+`axis4_reasoning_termination`.
+
+```json
+{"axis": "axis2_legal", "source": "neo4j_headnote:text", "text": "{\"messages\":[...]}", "meta": {...}}
+```
+
+Routing during capture is **natural top-8**: the router's own
+`top8(sigmoid(x @ W_gate^T) + e_score_correction_bias)` decides which tokens
+reach which expert (recomputed in-hook; under `--verify-engine` the recompute
+is additionally audited against the served router's own logits and must agree
+on >=99% of tokens). Experts are never force-routed; experts that receive
+fewer than 1,024 routed tokens fall back to the layer-level Hessian at encode
+time (recorded in the done JSON, never fatal; the reference run had zero).
+
+To calibrate on your own data keep the same schema and re-point `--corpus`;
+the pinned corpus SHA in `capture_b300.py` exists to reproduce *this* build
+byte-for-byte — relax it if you substitute a corpus.
+
+## Stage A — plan + prefill capture (layers 3..77)
+
+```bash
+export WORK_ROOT=/workspace/tr3
+export BF16_SRC=/workspace/bf16                       # zai-org/GLM-5.2 (BF16)
+export OWNER_CORPUS=$WORK_ROOT/calib/reap_recall_calib.jsonl
+export BASE_ENCODER_PY=$WORK_ROOT/encode_tr3_v31.py
+export CUDA_HOME=/usr/local/cuda-12.9
+
+./convert_b300.sh preflight     # env + corpus + HBM smoke checks
+./convert_b300.sh ext           # build the sm_100 exllamav3 0.0.43 ops
+./convert_b300.sh plan          # deterministic capture manifest
+```
+
+The capture boots vLLM TP8 with `enforce_eager`, prefix caching off,
+`max_tokens=1`, `ignore_eos` — captured tokens equal the sum of prompt
+lengths exactly (asserted per layer). A `forward_pre_hook` on
+`model.layers.{L}.mlp.experts` streams `x.bin` (bf16-as-int16 `[N, 6144]`)
+and `ids.bin` (uint8 `[N, 8]`) into `/dev/shm`, windows of at most 8 layers
+at a time. Each window's layers are striped across the 8 TP ranks (one owner
+rank per layer, `assigned = active_layers[rank::world]`; the MoE input is
+TP-replicated, so a single rank sees the full token stream; the owner rank is
+recorded in `layer_manifest.json`). Rank-0-only capture is the stage-B
+plugin's behavior, not stage A's:
+
+```bash
+for W in 3-10 11-18 19-26 27-34 35-42 43-50 51-58 59-66 67-74 75-77; do
+  LAYERS=$W ./convert_b300.sh capture-window
+  LAYERS=$W ./convert_b300.sh encode-window
+done
+```
+
+Per layer: 1,050,468 tokens, `layer_manifest.json` with payload SHA-256s and
+the full 256-expert routed-count histogram.
+
+## Stage B — MTP layer-78 capture (serving)
+
+The MTP module never executes during the offline prefill capture — it is the
+speculative draft, and it only runs when speculative decoding is enabled. Its
+expert inputs are therefore captured **while serving the corpus with MTP on**,
+using the `mtp78_xcapture.py` vLLM general-plugin published in
+[`malaiwah/GLM-5.2-EXL3-TR3-MTP78`](https://huggingface.co/malaiwah/GLM-5.2-EXL3-TR3-MTP78)
+`tools/` (which also documents the plugin's deadlock-free ring design: the
+forward path does device-side async enqueue only; a background thread drains
+chunks; TP rank 0 captures; `GO`/`STOP` marker files gate the window so
+boot/profiling traffic is excluded).
+
+```bash
+# serve the checkpoint with MTP enabled and the plugin armed:
+VLLM_MTP_CAPTURE_DIR=/workspace/mtp78_capture \
+VLLM_MTP_CAPTURE_MAX_TOKENS=8000000 \
+MTP_CAPTURE_LAYER_PREFIX=model.layers.78.mlp \
+vllm serve ... --speculative-config '{"method":"mtp","num_speculative_tokens":3,...}'
+
+touch /workspace/mtp78_capture/GO      # open the capture window
+python3 drive_corpus.py                # drive all 12,228 rows, prefill-only
+touch /workspace/mtp78_capture/STOP    # then one tiny request to finalize
+```
+
+The corpus drive matches stage-A semantics exactly: one request per row, raw
+`record["text"]`, checkpoint tokenizer, 4,096-token cap, `max_tokens=1`,
+temperature 0, `ignore_eos`. Because the draft prefills every prompt token,
+one pass over the corpus yields the **full-corpus** capture: **7,288,310
+tokens** with the router's ground-truth top-8 ids (the reference capture is
+published as
+[`malaiwah/GLM-5.2-MTP78-calibration-capture`](https://huggingface.co/datasets/malaiwah/GLM-5.2-MTP78-calibration-capture)
+— with it, re-encoding layer 78 is a pure-compute job and stage B can be
+skipped entirely; the dataset ships safetensors shards, so reconstruct
+`x.bin`/`ids.bin` with `scripts/load_capture_safetensors.py` from the
+malaiwah collector repo — `capture_done.json` is included — and point
+`MTP78_CAPTURE_SRC` at the result).
+
+Two serving-image caveats observed on the reference run (RC2-lineage image):
+the draft crashed on prefill steps larger than its decode-path threshold, so
+the serve config set `--max-num-batched-tokens` to that threshold and let the
+scheduler chunk every prefill; and prompts whose final chunk would be 1..8
+tokens were trimmed to a 128-multiple to dodge a fork-kernel fault. Neither
+affects capture semantics (the ids are the router's own output either way).
+
+Import the capture into the b300 layout (validates row parity, id range,
+routed histogram, bf16 sanity; writes `layer_078/layer_manifest.json` with
+the same `glm52-b300-layer-capture-v1` schema stage A emits):
+
+```bash
+# one-time: the finalize script ships with this page, not the HF bundle
+cp glm52-exl3-tr3-quantization-2026-07-26/scripts/finalize_mtp78_capture.py \
+   <calibration_encoder>/            # next to convert_b300.sh (stage fail-closes if absent)
+
+MTP78_CAPTURE_SRC=/workspace/mtp78_capture ./convert_b300.sh mtp78-import
+```
+
+## Stage C — calibrated LDLQ / trellis encode (now incl. layer 78)
+
+```bash
+LAYERS=78 ./convert_b300.sh encode-window
+```
+
+The patched `--layers` default is `3-78`; a full-range invocation fail-closes
+up front in `check_capture` unless the layer-78 capture is already imported
+(the windowed loop above never hits this).
+
+Identical math to layers 3..77, per expert, per TP4 slice:
+
+- gate/up (k=6144): `H_e = X_e^T X_e` over the tokens routed to expert `e`;
+  all 8 gate/up slices of an expert share one 6144x6144 `H` (reference
+  shared-qmap semantics — `su` drawn once per expert at first finalize, `sv`
+  per slice).
+- down (k=512): `I_e = silu(X_e Wg^T) * (X_e Wu^T)` computed offline from the
+  stored routed `x` with the BF16 gate/up weights; slice `r` uses the
+  `[512r, 512r+512)` **diagonal block** of `I_e^T I_e`.
+- `finalize_capture_H` (mean + 0.025 sigma damping + su transform) -> block
+  LDL(16) with damping retries -> LDLQ (128-row spans, 16-row blocks,
+  bottom-up, error feedback) -> MCG trellis pack at 3 bits, exllamav3 0.0.43
+  math vendored verbatim, v3.1 cross-slice lockstep + pooled GSS (oracle gate:
+  byte-equality vs v2 sequential on real slices).
+
+Layer 78's expert tensors follow the identical output schema
+(`model.layers.78.mlp.experts.{E}.{proj}.rank{r}.{trellis|suh|svh|mcg}`,
+12,288 tensors), so the encoder needs no naming changes — only the layer-range
+guards (see patch list below).
+
+## Stage D — assemble
+
+```bash
+./convert_b300.sh assemble
+```
+
+With the patches applied, assembly emits for layer 78 exactly what it emits
+for every other MoE layer, and the artifact-level metadata comes out in its
+final (post-graft-equivalent) state directly:
+
+- `model-layer-078.safetensors`: the 23 BF16 non-expert tensors + 12,288
+  trellis tensors (the BF16 expert `.weight` entries are dropped and audited
+  as replaced).
+- `config.json`: `hybrid_tr3_tail.moe_layers = [3, 78]`;
+  `quantization_config.ignore` carries `model.layers.78.eh_proj*` instead of
+  `model.layers.78*` (attention/shared-experts/router wildcards already cover
+  the rest of the layer's non-expert linears).
+- `tier_bitmap.json`: gains `"78"` with the real per-expert
+  `expert_rel_rt_mse` from the encode (the graft route had to add this entry
+  by hand).
+- Audits scale to 76 layers: 933,888 trellis tensors, 58,368 replaced BF16
+  weights.
+- Config-level `calibration.tokens_per_layer` (1,050,468) describes the
+  prefill plan; layer 78's 7,288,310-token serving capture is recorded in its
+  done JSON and in the per-layer SHA maps.
+
+## Serving requirements (tr3 MTP-78)
+
+Loading a **trellis** layer-78 draft needs runtime support the BF16 head did
+not (all carried in
+[local-inference-lab/vllm#139](https://github.com/local-inference-lab/vllm/pull/139)
+— commit `f57d093f` "exl3(mtp): load rank-sliced tr3 experts in the MTP
+draft layer", hash as of the current v20 rebase; PR open at the time of
+writing):
+
+1. **Draft quant-config hydration** — `get_draft_quant_config` must run the
+   same `maybe_update_config` the target runs, so the draft's
+   `Exl3Config.rank_sliced_metadata` is populated (otherwise the MTP experts
+   silently build a stock FusedMoE and fail on the tr3 tensors).
+2. **Rank-slice name normalization** — `deepseek_mtp.py::load_weights` must
+   call `quant_config.normalize_rank_sliced_weight_name(name)` like
+   `deepseek_v2.py` does (otherwise: `KeyError ...routed_experts.w2_rank0.mcg`).
+   On RC2-lineage images this is the published 1-hunk
+   `deepseek_mtp_normalization.patch`.
+3. **`VLLM_EXL3_TRELLIS_MIN_M=1`** — the trellis kernel's decode plan window
+   defaults to `[4, 32]`; the MTP-3 draft is cudagraph-captured at m=1,2,3,
+   which is illegal during capture without lowering the floor. Required for
+   any tr3 MTP layer.
+
+Everything else (`-tp 4`, the `hybrid_tr3_tail` block driving the pre-planned
+CUDA-graph-safe kernel path) is unchanged from the model card's runtime
+section.
+
+## Retrofit path (already-built 3..77 checkpoints)
+
+An existing checkpoint with a BF16 MTP head does not need a re-run: encode
+layer 78 from the published capture dataset and graft the merged shard
+(`build_graft.py` in the malaiwah `tools/`: hardlink clone, merged layer-078
+shard, index rebuild, the ignore-list and `moe_layers` config edits). That
+route — plus two by-hand touches the shipped artifact carries
+(`model.layers.78.eh_proj*` retained on the ignore list, where
+`build_graft.py` strips every `layers.78` entry, and the `tier_bitmap`
+`"78"` entry) — produced the shipped `-MTP78` checkpoint (commit `41a1c8ae`); the patches on this page produce the same end state in one pass,
+with truthful per-layer calibration metadata baked in from the start.
+
+## Changes vs the published `calibration_encoder/` scripts
+
+The published bundle reproduces the checkpoint **as originally shipped**
+(BF16 MTP head). The patches in
+[`glm52-exl3-tr3-quantization-2026-07-26/patches/`](glm52-exl3-tr3-quantization-2026-07-26/patches/)
+apply cleanly to the pinned files and fold the MTP-78 leg in. Every hunk:
+
+### `01-encode_tr3_v31-mtp78.patch` (5 hunks)
+
+| Change | Why |
+|---|---|
+| `moe_layers()`: `range(3, 78)` -> `range(3, 79)` | Layer 78 joins the encode/assembly set; `hybrid_tr3_tail.moe_layers` becomes `[3, 78]` automatically, and the assembly `dropped`/`tier_bitmap` sets follow this list. |
+| layer-guard assert: `3 <= L < 78` -> `3 <= L <= 78` | `--layers 78` was rejected as "not a main MoE layer". |
+| `--layers` default `3-77` -> `3-78`, help text | Full-run default covers the MTP layer. |
+| Header/comment scope text | Documentation consistency (`3..77` -> `3..78`). |
+| Side effect: patched v31's own standalone `--assemble` now also requires an encoded layer 78 | Unused by this pipeline (the adapter assembles); noted for direct-v31 users. Two cosmetic v31 strings (a usage example reading `3-77`, a bench log reading `75 layers`) are deliberately left unpatched to keep the encoder diff and its SHA pin minimal. |
+
+### `02-encode_b300-mtp78.patch` (13 hunks)
+
+| Change | Why |
+|---|---|
+| `EXPECTED_TOTAL_TR3_TENSORS = 75 * ...` -> `76 * ...`; `EXPECTED_REPLACED_WEIGHTS = 75 * 256 * 3` -> `76 * ...` | Output audits count layer 78's 12,288 trellis tensors / 768 replaced weights. |
+| `BASE_ENCODER_SHA256` re-pinned to `3bc6839fbb35074a369673748b1effa9b74346cfe7162390e5bbb943926004e4` | The adapter refuses an encoder whose bytes differ from the pin; the patched `encode_tr3_v31.py` hashes differently by design. |
+| recipe scope `"layers": [3, 77]` -> `[3, 78]` | The recipe fingerprint is a whole-run property; **it must be set before encoding layer 3**, and all 76 done JSONs must carry the same fingerprint (a 3..77 work dir cannot be retrofitted — use the graft path for that). |
+| dispatch-shim ignore: `model.layers.78*` -> `model.layers.78.eh_proj*` | Layer-78 experts now go down the intercepted path; only `eh_proj` (a layer-78-specific linear no generic wildcard covers) stays BF16-ignored. Matches the shipped `-MTP78` config exactly. |
+| `hybrid_tr3_tail`: `moe_layers [3,77]` -> `[3,78]`, scope strings, BF16 list, dispatch note | Runtime discovers trellis layers from `moe_layers`; scope text stops claiming the MTP head is BF16. |
+| done-JSON capture block: prefer `layer_manifest` `tokens`/`capture_fingerprint` over plan values | Layer 78's manifest records the serving capture truthfully (7,288,310 tokens, its own fingerprint); layers 3..77 are unaffected (their manifests carry the plan values). |
+| `--layers` default `3-77` -> `3-78` | Same as the encoder. |
+| New `validate_mtp78_manifest()` + constants (`MTP_LAYER`, transport/schema markers, 1,048,576-token floor); `check_capture` and `LayerCalibRAM` dispatch layer 78 to it | The serving capture carries its own corpus-pinned fingerprint (recomputed via `canonical_hash`, fail-closed — tampering with tokens or payload SHAs is detected) and its own token count; layers 3..77 keep the plan checks verbatim. Without this the adapter hard-rejects the layer-78 manifest before any encode. |
+| Assemble re-hash log made dynamic (`57,600` -> `len(layers)*768`) | Count correctness at 76 layers. |
+
+### `03-convert_b300-mtp78.patch` (3 hunks)
+
+| Change | Why |
+|---|---|
+| New `mtp78-import` stage (`MTP78_CAPTURE_SRC=<dir> ./convert_b300.sh mtp78-import`) | Imports/validates the serving-time capture into `CAPTURE_DIR/layer_078/` behind the same RAM guard the prefill windows use; fail-closes (and `py_compile`s) if `finalize_mtp78_capture.py` has not been copied next to `convert_b300.sh`. |
+| Case-switch + usage text | Stage discoverability. |
+
+### New files
+
+| File | Role |
+|---|---|
+| [`scripts/finalize_mtp78_capture.py`](glm52-exl3-tr3-quantization-2026-07-26/scripts/finalize_mtp78_capture.py) | Validates the plugin capture (row parity, id range, routed histogram, duplicate-id pre-check, bf16 sanity, drop budget) and writes `layer_078/layer_manifest.json` in the stage-A schema with a corpus-pinned canonical fingerprint the patched adapter recomputes and enforces; `encode_b300.py --encode --layers 78` consumes it unchanged. |
+
+Not vendored here: `mtp78_xcapture.py`, `drive_corpus.py`,
+`deepseek_mtp_normalization.patch`, `build_graft.py` — published and
+maintained in `malaiwah/GLM-5.2-EXL3-TR3-MTP78` `tools/`.
+
+## Links
+
+- Checkpoint: [`brandonmusic/GLM-5.2-EXL3-TR3-3.0bpw`](https://huggingface.co/brandonmusic/GLM-5.2-EXL3-TR3-3.0bpw) (tr3 MTP-78 head since commit `41a1c8ae`)
+- Reproduction bundle (as-shipped recipe): [`calibration_encoder/`](https://huggingface.co/brandonmusic/GLM-5.2-EXL3-TR3-3.0bpw/tree/main/calibration_encoder)
+- MTP-78 overlays + tools: [`malaiwah/GLM-5.2-EXL3-TR3-MTP78`](https://huggingface.co/malaiwah/GLM-5.2-EXL3-TR3-MTP78)
+- Layer-78 capture dataset: [`malaiwah/GLM-5.2-MTP78-calibration-capture`](https://huggingface.co/datasets/malaiwah/GLM-5.2-MTP78-calibration-capture)
+- Runtime loader fixes: [local-inference-lab/vllm#139](https://github.com/local-inference-lab/vllm/pull/139); sparkinfer counterpart [local-inference-lab/sparkinfer#49](https://github.com/local-inference-lab/sparkinfer/pull/49)
+- exllamav3 (LDLQ/trellis reference math, 0.0.43): [turboderp-org/exllamav3](https://github.com/turboderp-org/exllamav3)
+
+## Credits
+
+zai-org (GLM-5.2 base, MIT) - Brandon Music (EXL3 TR3 encoder, owner corpus,
+base checkpoint, runtime PRs) - Josh Cartu / jcartu (MTP78 recipe, rank-sliced
+MTP runtime) - malaiwah (layer-78 capture/encode/validation + published
+overlays and capture dataset) - Luke Alonso (b12x) - turboderp-org
+(exllamav3, MIT).

--- a/models/glm5.2/glm52-exl3-tr3-quantization-2026-07-26/patches/01-encode_tr3_v31-mtp78.patch
+++ b/models/glm5.2/glm52-exl3-tr3-quantization-2026-07-26/patches/01-encode_tr3_v31-mtp78.patch
@@ -1,0 +1,49 @@
+--- a/calibration_encoder/encode_tr3_v31.py
++++ b/calibration_encoder/encode_tr3_v31.py
+@@ -43,7 +43,7 @@
+ Builds the KLC hybrid checkpoint from lukealonso/GLM-5.2-NVFP4 (ModelOpt-style
+ NVFP4, 87 shards):
+ 
+-  * per MoE layer (3..77): encode ALL 256 routed experts with EXL3 trellis at
++  * per MoE layer (3..78, incl. the MTP layer 78): encode ALL 256 routed experts with EXL3 trellis at
+     exactly 3.0 bpw via the exllamav3 v0.0.43 CALIBRATED path (finalize_capture_H
+     -> block LDL -> ldlq blocked quantization with error feedback), TP4 per-slice
+     (gate/up N-sliced 4x[512,6144], down K-sliced 4x[6144,512], each slice its
+@@ -158,7 +158,7 @@
+ HCHUNK = 65536                # row chunk for H accumulation matmuls
+ 
+ FIRST_MOE_LAYER = 3           # config.first_k_dense_replace
+-NUM_LAYERS = 78               # config.num_hidden_layers (layer 78 = MTP, carried)
++NUM_LAYERS = 78               # config.num_hidden_layers (layer 78 = MTP; experts trellis-encoded like 3..77)
+ NUM_EXPERTS = 256             # config.n_routed_experts
+ HIDDEN = 6144                 # config.hidden_size
+ MOE_INTER = 2048              # config.moe_intermediate_size
+@@ -361,7 +361,7 @@
+         return self._readers[p]
+ 
+     def moe_layers(self):
+-        return list(range(FIRST_MOE_LAYER, NUM_LAYERS))  # 3..77 (78 = MTP, carried)
++        return list(range(FIRST_MOE_LAYER, NUM_LAYERS + 1))  # 3..78 (incl. MTP layer 78 experts)
+ 
+ 
+ def expert_key(L, E, proj, suffix):
+@@ -2060,7 +2060,7 @@
+         elif part:
+             out.append(int(part))
+     for L in out:
+-        assert FIRST_MOE_LAYER <= L < NUM_LAYERS, f"layer {L} is not a main MoE layer"
++        assert FIRST_MOE_LAYER <= L <= NUM_LAYERS, f"layer {L} is not a MoE layer (3..{NUM_LAYERS} incl. MTP)"
+     return sorted(set(out))
+ 
+ 
+@@ -2750,8 +2750,8 @@
+     ap.add_argument("--work", default=DEF_WORK)
+     ap.add_argument("--out", default=DEF_OUT)
+     ap.add_argument("--repo", default=DEF_REPO)
+-    ap.add_argument("--layers", default=f"{FIRST_MOE_LAYER}-{NUM_LAYERS-1}",
+-                    help="e.g. '3-77' or '3,5,10-12'")
++    ap.add_argument("--layers", default=f"{FIRST_MOE_LAYER}-{NUM_LAYERS}",
++                    help="e.g. '3-78' or '3,5,10-12' (78 = MTP layer)")
+     ap.add_argument("--workers", type=int, default=4)
+     ap.add_argument("--gpus", type=int, default=4,
+                     help="physical GPU count; workers are assigned round-robin (worker r -> GPU r%%gpus)")

--- a/models/glm5.2/glm52-exl3-tr3-quantization-2026-07-26/patches/02-encode_b300-mtp78.patch
+++ b/models/glm5.2/glm52-exl3-tr3-quantization-2026-07-26/patches/02-encode_b300-mtp78.patch
@@ -1,0 +1,194 @@
+--- a/calibration_encoder/encode_b300.py
++++ b/calibration_encoder/encode_b300.py
+@@ -23,14 +23,19 @@
+ import traceback
+ 
+ 
+-BASE_ENCODER_SHA256 = "e9a85a47e165c8d8644354cef611efbb81dfd9ba88544ca59f0c80ee6bc75032"
++BASE_ENCODER_SHA256 = "3bc6839fbb35074a369673748b1effa9b74346cfe7162390e5bbb943926004e4"  # encode_tr3_v31.py + mtp78 patch
+ CORPUS_SHA256 = "cf247acc7c5da9f0600c7d6ab3b7c2fcfc54ec30b794e3b6047559285fa44df4"
+ EXPECTED_SHARDS = 282
+ EXPECTED_LAYER_TENSORS = 256 * 3 * 4 * 4
+-EXPECTED_TOTAL_TR3_TENSORS = 75 * EXPECTED_LAYER_TENSORS
+-EXPECTED_REPLACED_WEIGHTS = 75 * 256 * 3
++EXPECTED_TOTAL_TR3_TENSORS = 76 * EXPECTED_LAYER_TENSORS  # layers 3..78 incl. MTP
++EXPECTED_REPLACED_WEIGHTS = 76 * 256 * 3  # layers 3..78 incl. MTP
+ CAPTURE_PLAN_SCHEMA = "glm52-b300-capture-plan-v1"
+ DONE_SCHEMA = "glm52-b300-exl3-layer-v1"
++MTP_LAYER = 78
++MTP78_CAPTURE_TRANSPORT = "mtp78_xcapture-serving"
++MTP78_FINGERPRINT_SCHEMA = "glm52-mtp78-serving-capture-v1"
++MTP78_TARGET_PREFIX = "model.layers.78.mlp"
++MTP78_MIN_TOKENS = 1_048_576
+ ADAPTER_VERSION = "1"
+ RAM_FILESYSTEMS = {"tmpfs", "ramfs"}
+ GIB = 1 << 30
+@@ -268,7 +273,7 @@
+         "adapter_version": ADAPTER_VERSION,
+         "exllamav3": "0.0.43",
+         "scope": {
+-            "layers": [3, 77],
++            "layers": [3, 78],
+             "experts_per_layer": 256,
+             "projections": ["gate_proj", "up_proj", "down_proj"],
+             "keep_nvfp4": 0,
+@@ -377,7 +382,9 @@
+ 
+         layer_dir = Path(capture_dir) / f"layer_{layer:03d}"
+         manifest = json.loads((layer_dir / "layer_manifest.json").read_text())
+-        if manifest.get("capture_fingerprint") != getattr(self.__class__, "expected_fingerprint", None):
++        if layer == MTP_LAYER:
++            validate_mtp78_manifest(layer, manifest)
++        elif manifest.get("capture_fingerprint") != getattr(self.__class__, "expected_fingerprint", None):
+             raise RuntimeError(f"layer {layer}: RAM capture fingerprint mismatch")
+         self.manifest = manifest
+         self.L = layer
+@@ -485,6 +492,36 @@
+     return tensor.to(device)
+ 
+ 
++def validate_mtp78_manifest(layer: int, manifest: dict) -> int:
++    """Fail-closed validation of the serving-time MTP layer-78 capture.
++
++    Layers 3..77 are validated against the prefill capture plan.  The MTP
++    layer's manifest (written by finalize_mtp78_capture.py) instead binds
++    tokens + payload SHAs + the owner-pinned corpus into its own fingerprint.
++    Returns the manifest token count; payload sizes derive from it.
++    """
++    if layer != MTP_LAYER or manifest.get("capture_transport") != MTP78_CAPTURE_TRANSPORT:
++        raise RuntimeError(f"layer {layer}: not a valid MTP78 serving-capture manifest")
++    if manifest.get("corpus_sha256") != CORPUS_SHA256:
++        raise RuntimeError(f"layer {layer}: MTP78 capture does not use the owner-pinned corpus")
++    tokens = int(manifest.get("tokens", -1))
++    material = {
++        "schema": MTP78_FINGERPRINT_SCHEMA,
++        "corpus_sha256": manifest.get("corpus_sha256"),
++        "target_prefix": MTP78_TARGET_PREFIX,
++        "tokens": tokens,
++        "sha256_x": manifest.get("sha256_x"),
++        "sha256_ids": manifest.get("sha256_ids"),
++    }
++    if manifest.get("capture_fingerprint") != canonical_hash(material):
++        raise RuntimeError(f"layer {layer}: MTP78 capture fingerprint is invalid")
++    if tokens < MTP78_MIN_TOKENS:
++        raise RuntimeError(
++            f"layer {layer}: MTP78 capture has {tokens} tokens, floor is {MTP78_MIN_TOKENS}"
++        )
++    return tokens
++
++
+ def check_capture(capture_dir: str, layers: list[int], plan: dict) -> None:
+     assert_ram_capture_target(Path(capture_dir))
+     tokens = int(plan["total_tokens"])
+@@ -494,13 +531,19 @@
+             manifest = json.loads((layer_dir / "layer_manifest.json").read_text())
+         except Exception as exc:
+             raise RuntimeError(f"layer {layer}: RAM capture manifest missing ({exc})") from exc
+-        if manifest.get("capture_fingerprint") != plan["capture_fingerprint"]:
+-            raise RuntimeError(f"layer {layer}: RAM capture belongs to a different plan")
+-        if int(manifest.get("tokens", -1)) != tokens:
+-            raise RuntimeError(f"layer {layer}: RAM capture token count mismatch")
+-        if (layer_dir / "x.bin").stat().st_size != tokens * BASE.HIDDEN * 2:
++        if layer == MTP_LAYER:
++            # Serving-time capture: tokens/sizes come from the manifest itself,
++            # bound to the owner corpus via the manifest's own fingerprint.
++            layer_tokens = validate_mtp78_manifest(layer, manifest)
++        else:
++            if manifest.get("capture_fingerprint") != plan["capture_fingerprint"]:
++                raise RuntimeError(f"layer {layer}: RAM capture belongs to a different plan")
++            if int(manifest.get("tokens", -1)) != tokens:
++                raise RuntimeError(f"layer {layer}: RAM capture token count mismatch")
++            layer_tokens = tokens
++        if (layer_dir / "x.bin").stat().st_size != layer_tokens * BASE.HIDDEN * 2:
+             raise RuntimeError(f"layer {layer}: x RAM payload incomplete")
+-        if (layer_dir / "ids.bin").stat().st_size != tokens * 8:
++        if (layer_dir / "ids.bin").stat().st_size != layer_tokens * 8:
+             raise RuntimeError(f"layer {layer}: ids RAM payload incomplete")
+ 
+ 
+@@ -564,8 +607,10 @@
+             "source_expert_tensor_count": ACTIVE_SOURCE_TENSORS,
+             "tensor_count": EXPECTED_LAYER_TENSORS,
+             "capture": {
+-                "fingerprint": args.capture_plan["capture_fingerprint"],
+-                "tokens": int(args.capture_plan["total_tokens"]),
++                "fingerprint": layer_manifest.get(
++                    "capture_fingerprint", args.capture_plan["capture_fingerprint"]
++                ),
++                "tokens": int(layer_manifest.get("tokens", args.capture_plan["total_tokens"])),
+                 "sha256_x": layer_manifest["sha256_x"],
+                 "sha256_ids": layer_manifest["sha256_ids"],
+             },
+@@ -683,8 +728,9 @@
+     """Compatibility metadata that selects the b12x ModelOpt interception.
+ 
+     There are zero NVFP4 payload tensors.  The ignore list leaves only routed
+-    experts in layers 3..77 on the intercepted path; MTP layer 78 is wholly
+-    ignored so its BF16 experts are loaded normally.
++    experts in layers 3..78 (incl. the MTP layer) on the intercepted path;
++    layer-78's eh_proj stays ignored (BF16), everything else non-expert is
++    covered by the generic wildcards.
+     """
+     return {
+         "config_groups": {
+@@ -714,7 +760,7 @@
+             "model.layers.2.mlp*",
+             "*shared_experts*",
+             "*mlp.gate*",
+-            "model.layers.78*",
++            "model.layers.78.eh_proj*",
+         ],
+         "quant_algo": "NVFP4",
+         "producer": {"name": "b300-exl3-modelopt-dispatch-shim", "version": ADAPTER_VERSION},
+@@ -782,7 +828,7 @@
+     from multiprocessing import get_context
+ 
+     BASE.log(
+-        "assemble: re-hashing all 57,600 routed BF16 source tensors against encode-time digests",
++        f"assemble: re-hashing all {len(layers) * 256 * 3:,} routed BF16 source tensors against encode-time digests",
+         logfile,
+     )
+     jobs = [(src_path, layer) for layer in layers]
+@@ -889,7 +935,7 @@
+         "mcg_multiplier": BASE.MCG_MULT,
+         "hessian": "ldlq-calibrated",
+         "exllamav3_version": "0.0.43",
+-        "moe_layers": [3, 77],
++        "moe_layers": [3, 78],
+         "experts_per_layer": 256,
+         "nvfp4_keep_per_layer": 0,
+         "tr3_tail_per_layer": 256,
+@@ -921,13 +967,13 @@
+             "per_layer_ids_sha256": per_ids,
+         },
+         "scope": {
+-            "quantized": "routed MoE expert gate/up/down projections, all 256 experts, layers 3..77",
++            "quantized": "routed MoE expert gate/up/down projections, all 256 experts, layers 3..78 (incl. MTP layer 78)",
+             "bf16_byte_exact": [
+                 "attention",
+                 "dense MLPs layers 0..2",
+                 "shared experts",
+                 "router/gates",
+-                "MTP layer 78",
++                "MTP layer 78 non-expert tensors (eh_proj, enorm, hnorm, attention, shared experts, router/gate, shared_head.norm)",
+                 "embeddings",
+                 "lm_head",
+             ],
+@@ -941,7 +987,7 @@
+         "tier_bitmap": "tier_bitmap.json",
+         "modelopt_dispatch_note": (
+             "quantization_config selects the b12x ModelOpt interception only; this artifact "
+-            "contains zero NVFP4 expert payloads. Layer 78 is ignored and remains BF16."
++            "contains zero NVFP4 expert payloads. Layer-78 routed experts are EXL3 trellis; only eh_proj stays on the ignore list (BF16)."
+         ),
+     }
+     atomic_json(out / "config.json", config)
+@@ -1023,7 +1069,7 @@
+     parser.add_argument("--out", default="")
+     parser.add_argument("--capture-dir", default="/dev/shm/glm52-tr3-capture")
+     parser.add_argument("--capture-manifest", default="/workspace/tr3/capture_plan.json")
+-    parser.add_argument("--layers", default="3-77")
++    parser.add_argument("--layers", default="3-78")
+     parser.add_argument("--workers", type=int, default=8)
+     parser.add_argument("--gpus", type=int, default=8)
+     parser.add_argument("--io-workers", type=int, default=8)

--- a/models/glm5.2/glm52-exl3-tr3-quantization-2026-07-26/patches/03-convert_b300-mtp78.patch
+++ b/models/glm5.2/glm52-exl3-tr3-quantization-2026-07-26/patches/03-convert_b300-mtp78.patch
@@ -1,0 +1,42 @@
+--- a/calibration_encoder/convert_b300.sh
++++ b/calibration_encoder/convert_b300.sh
+@@ -113,6 +113,23 @@
+         --layers "$LAYERS" --workers 8 --gpus 8
+ }
+ 
++mtp78_import() {
++    # Import a serving-time MTP layer-78 capture (mtp78_xcapture.py vLLM plugin)
++    # into the b300 capture layout: CAPTURE_DIR/layer_078/{x.bin,ids.bin,
++    # layer_manifest.json}. The MTP layer never executes during the offline
++    # prefill capture pass, so its expert inputs are captured while SERVING the
++    # corpus with speculative decoding enabled, then imported here.
++    local src_dir="${MTP78_CAPTURE_SRC:?set MTP78_CAPTURE_SRC=<dir with x.bin/ids.bin/capture_done.json>}"
++    [[ -f "$SCRIPT_DIR/finalize_mtp78_capture.py" ]] || \
++        die "finalize_mtp78_capture.py missing next to convert_b300.sh; copy it from the page's scripts/ dir"
++    "$PYTHON" -m py_compile "$SCRIPT_DIR/finalize_mtp78_capture.py"
++    local payload
++    payload=$(( $(stat -c '%s' "${src_dir}/x.bin") + $(stat -c '%s' "${src_dir}/ids.bin") ))
++    ram_guard "$CAPTURE_DIR" "$payload" "mtp78 import"
++    "$PYTHON" "$SCRIPT_DIR/finalize_mtp78_capture.py" \
++        --src-dir "$src_dir" --capture-dir "$CAPTURE_DIR" --corpus "$OWNER_CORPUS"
++}
++
+ assemble_output() {
+     disk_guard "$OUT_DIR" 549755813888 "assembled checkpoint"
+     "$PYTHON" "$SCRIPT_DIR/encode_b300.py" --assemble \
+@@ -125,6 +142,7 @@
+     ext) build_ext ;;
+     plan) build_plan ;;
+     capture-window) capture_window ;;
++    mtp78-import) mtp78_import ;;
+     encode-window) encode_window ;;
+     assemble) assemble_output ;;
+     status)
+@@ -132,6 +150,6 @@
+         df -h /workspace /dev/shm
+         ;;
+     *)
+-        die "usage: $0 {preflight|ext|plan|capture-window|encode-window|assemble|status}; set LAYERS to an <=8-layer comma list"
++        die "usage: $0 {preflight|ext|plan|capture-window|mtp78-import|encode-window|assemble|status}; set LAYERS to an <=8-layer comma list (78 = MTP layer, capture via mtp78-import)"
+         ;;
+ esac

--- a/models/glm5.2/glm52-exl3-tr3-quantization-2026-07-26/scripts/finalize_mtp78_capture.py
+++ b/models/glm5.2/glm52-exl3-tr3-quantization-2026-07-26/scripts/finalize_mtp78_capture.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Import a serving-time MTP layer-78 capture into the b300 capture layout.
+
+The MTP draft layer (78) never executes during the offline prefill capture
+pass (`capture_b300.py` hooks the target model; the draft only runs under
+speculative decoding), so its expert inputs are captured while SERVING the
+calibration corpus with MTP enabled — via the `mtp78_xcapture.py` vLLM
+general-plugin (see malaiwah/GLM-5.2-EXL3-TR3-MTP78 `tools/`), which writes
+Brandon Music's exact TR3 capture format:
+
+    x.bin   : int16 (bf16 bit-pattern) [tokens, 6144]  MoE-input hidden states
+    ids.bin : uint8                    [tokens, 8]     routed top-8 expert ids
+    capture_done.json : {tokens, dropped_rows, target_prefix, ...}
+
+This script validates that payload, computes the audit fields, and emits
+`CAPTURE_DIR/layer_078/{x.bin,ids.bin,layer_manifest.json}` with the same
+`glm52-b300-layer-capture-v1` schema `capture_b300.py` writes for layers
+3..77, so `encode_b300.py --encode --layers 78` consumes it unchanged.
+
+Differences vs a prefill-captured layer, recorded honestly in the manifest:
+  - `tokens` is the serving-capture count (full corpus, e.g. 7,288,310), not
+    the prefill plan quota; the patched `encode_b300.py` records the
+    layer_manifest value into the layer's done JSON.
+  - `capture_fingerprint` is derived from this payload (corpus sha + prefix +
+    payload shas), not from the prefill capture plan.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import time
+from pathlib import Path
+
+import numpy as np
+
+HIDDEN = 6144
+TOPK = 8
+NUM_EXPERTS = 256
+TARGET_PREFIX = "model.layers.78.mlp"
+LAYER = 78
+
+
+def sha256_file(path: Path, chunk: int = 64 << 20) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while True:
+            block = handle.read(chunk)
+            if not block:
+                break
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--src-dir", required=True,
+                    help="mtp78_xcapture output dir (x.bin, ids.bin, capture_done.json)")
+    ap.add_argument("--capture-dir", required=True,
+                    help="b300 CAPTURE_DIR; layer_078/ is created inside it")
+    ap.add_argument("--corpus", required=True,
+                    help="calibration corpus jsonl (sha256 recorded in the manifest)")
+    ap.add_argument("--min-tokens", type=int, default=1_048_576,
+                    help="refuse captures smaller than the b300 per-layer floor")
+    ap.add_argument("--max-dropped-frac", type=float, default=0.001,
+                    help="refuse if the ring dropped more than this fraction of rows")
+    args = ap.parse_args()
+
+    src = Path(args.src_dir)
+    x_path, ids_path = src / "x.bin", src / "ids.bin"
+    done_path = src / "capture_done.json"
+    for path in (x_path, ids_path, done_path):
+        if not path.is_file():
+            raise SystemExit(f"FATAL: missing {path}")
+    done = json.loads(done_path.read_text())
+
+    if int(done.get("hidden", HIDDEN)) != HIDDEN or int(done.get("topk", TOPK)) != TOPK:
+        raise SystemExit("FATAL: capture_done geometry mismatch")
+    if done.get("target_prefix") != TARGET_PREFIX:
+        raise SystemExit(
+            f"FATAL: capture target_prefix={done.get('target_prefix')!r}, "
+            f"expected {TARGET_PREFIX!r}"
+        )
+
+    x_bytes, ids_bytes = x_path.stat().st_size, ids_path.stat().st_size
+    if x_bytes % (HIDDEN * 2) or ids_bytes % TOPK:
+        raise SystemExit("FATAL: payload sizes are not row-aligned")
+    tokens = x_bytes // (HIDDEN * 2)
+    if ids_bytes // TOPK != tokens:
+        raise SystemExit(
+            f"FATAL: row mismatch x={tokens} ids={ids_bytes // TOPK} "
+            "(x.bin and ids.bin must cover the same rows)"
+        )
+    if int(done.get("tokens", -1)) != tokens:
+        raise SystemExit(
+            f"FATAL: capture_done tokens={done.get('tokens')} != payload rows {tokens}"
+        )
+    if tokens < args.min_tokens:
+        raise SystemExit(f"FATAL: only {tokens} tokens captured, floor is {args.min_tokens}")
+    dropped = int(done.get("dropped_rows", 0))
+    if dropped > args.max_dropped_frac * (tokens + dropped):
+        raise SystemExit(
+            f"FATAL: ring dropped {dropped} rows "
+            f"(> {args.max_dropped_frac:.4%} of the stream)"
+        )
+
+    # Routed-count audit over the full ids payload (memory-mapped).
+    ids = np.memmap(ids_path, dtype=np.uint8, mode="r", shape=(tokens, TOPK))
+    if int(ids.max()) >= NUM_EXPERTS:
+        raise SystemExit(f"FATAL: expert id {int(ids.max())} out of range")
+    routed = np.bincount(ids.reshape(-1), minlength=NUM_EXPERTS).astype(int).tolist()
+    # Duplicate expert id within a token = x/ids ring skew in the capture
+    # plugin; catch it here, before the ~84 GiB tmpfs copy and the encoder's
+    # own late hard-fail on the same condition.
+    sorted_ids = np.sort(ids, axis=1)
+    if not (sorted_ids[:, 1:] != sorted_ids[:, :-1]).all():
+        raise SystemExit("FATAL: duplicate expert id within a token (x/ids ring skew?)")
+
+    # bf16 sanity on a deterministic sample: finite, non-degenerate.
+    rows = np.linspace(0, tokens - 1, num=min(4096, tokens), dtype=np.int64)
+    x = np.memmap(x_path, dtype=np.int16, mode="r", shape=(tokens, HIDDEN))
+    import torch
+    sample = torch.from_numpy(np.ascontiguousarray(x[rows])).view(torch.bfloat16).float()
+    if not torch.isfinite(sample).all():
+        raise SystemExit("FATAL: non-finite values in sampled x rows")
+    if float(sample.abs().amax(dim=1).min()) == 0.0:
+        raise SystemExit("FATAL: all-zero row in sampled x rows")
+
+    sha_x, sha_ids = sha256_file(x_path), sha256_file(ids_path)
+    corpus_sha = sha256_file(Path(args.corpus))
+    fingerprint = hashlib.sha256(
+        json.dumps(
+            {
+                "schema": "glm52-mtp78-serving-capture-v1",
+                "corpus_sha256": corpus_sha,
+                "target_prefix": TARGET_PREFIX,
+                "tokens": tokens,
+                "sha256_x": sha_x,
+                "sha256_ids": sha_ids,
+            },
+            sort_keys=True,
+            separators=(",", ":"),  # must match encode_b300.canonical_hash
+        ).encode()
+    ).hexdigest()
+
+    layer_dir = Path(args.capture_dir) / f"layer_{LAYER:03d}"
+    layer_dir.mkdir(parents=True, exist_ok=True)
+    for name, source in (("x.bin", x_path), ("ids.bin", ids_path)):
+        dest = layer_dir / name
+        if dest.exists():
+            dest.unlink()
+        try:
+            os.link(source, dest)  # same filesystem: free
+        except OSError:
+            import shutil
+            shutil.copyfile(source, dest)
+
+    manifest = {
+        "schema": "glm52-b300-layer-capture-v1",
+        "layer": LAYER,
+        "capture_fingerprint": fingerprint,
+        "capture_transport": "mtp78_xcapture-serving",
+        "tokens": tokens,
+        "hidden": HIDDEN,
+        "x_dtype": "bfloat16",
+        "x_bytes": x_bytes,
+        "ids_topk": TOPK,
+        "ids_bytes": ids_bytes,
+        "sha256_x": sha_x,
+        "sha256_ids": sha_ids,
+        "routed_counts": routed,
+        "routed_min": min(routed),
+        "routed_max": max(routed),
+        "cold_experts_lt1024": [e for e, count in enumerate(routed) if count < 1024],
+        "dropped_rows": dropped,
+        "corpus_sha256": corpus_sha,
+        "finished": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+    }
+    tmp = layer_dir / "layer_manifest.json.tmp"
+    tmp.write_text(json.dumps(manifest, indent=2, sort_keys=True))
+    os.replace(tmp, layer_dir / "layer_manifest.json")
+
+    cold = manifest["cold_experts_lt1024"]
+    print(
+        f"MTP78 CAPTURE IMPORTED: {tokens} tokens, routed min/max="
+        f"{min(routed)}/{max(routed)}, cold(<1024)={len(cold)}, "
+        f"dropped={dropped}, fingerprint={fingerprint[:16]}…"
+    )
+    if cold:
+        print(f"  cold experts fall back to layer-level H at encode: {cold[:16]}"
+              + (" …" if len(cold) > 16 else ""))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a `models/glm5.2` page documenting the full conversion recipe behind
[`brandonmusic/GLM-5.2-EXL3-TR3-3.0bpw`](https://huggingface.co/brandonmusic/GLM-5.2-EXL3-TR3-3.0bpw):
GLM-5.2 753B BF16 routed experts -> 3.0-bpw EXL3 Trellis via calibrated LDLQ
(owner corpus, natural top-8 routing), TP4 rank-sliced, MCG codebook.

**One deliberate difference vs the checkpoint's own `calibration_encoder/README.md`:**
the MTP draft layer (78) routed experts are captured (serving-time, full
12,228-row corpus = 7,288,310 tokens) and trellis-encoded in-pass exactly like
layers 3..77, instead of being carried BF16 and grafted on afterwards — the
recipe the shipped `-MTP78` head converged on
([malaiwah/GLM-5.2-EXL3-TR3-MTP78](https://huggingface.co/malaiwah/GLM-5.2-EXL3-TR3-MTP78),
BF16 acceptance parity 3.06 vs 3.054, draft VRAM ~4.8 -> ~0.95 GB/GPU,
~+66% KV capacity).

Included under `models/glm5.2/`:
- `glm52-exl3-tr3-quantization-2026-07-26.md` — the page (pipeline, corpus,
  capture/encode/assemble stages, serving requirements incl.
  `VLLM_EXL3_TRELLIS_MIN_M=1` + the two loader fixes carried in
  local-inference-lab/vllm#139, exllamav3 0.0.43-vs-1.x codebook note, and a
  per-hunk change table vs the published scripts).
- `glm52-exl3-tr3-quantization-2026-07-26/patches/` — 3 patches (5/13/3 hunks)
  against the pinned HF `calibration_encoder` files; verified to apply
  byte-identically and compile.
- `glm52-exl3-tr3-quantization-2026-07-26/scripts/finalize_mtp78_capture.py` —
  imports the serving-time layer-78 capture into the b300 capture layout with
  a corpus-pinned, fail-closed fingerprint (mutation-tested).

All numbers are pinned to the shipped artifacts (configs, index, tier_bitmap,
RELEASE_TEST_SUITE) or the published malaiwah capture dataset; unverifiable
claims were removed during two independent review passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for quantizing and assembling GLM-5.2 MoE expert weights through layer 78, including the MTP layer.
  - Added an import workflow for serving-time MTP layer captures.
  - Added comprehensive validation for capture payloads, routing data, manifests, fingerprints, and runtime requirements.
  - Added documentation covering the complete conversion process, retrofit guidance, and operational requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->