### PR TITLE
Document clean reproducible GLM-5.2 v20 r6 with LMCache

### DIFF
--- a/models/glm5.2_v20.md
+++ b/models/glm5.2_v20.md
@@ -16,7 +16,9 @@ measured DCP prefill topology:
   that the development host's overlap policy is portable;
 - the launcher preserves an intentional `CUDA_VISIBLE_DEVICES` order when
   Compose leaves `GPUS` empty, allows 600 seconds for a cold probe, and
-  terminates the complete probe process group if calibration times out.
+  terminates the complete probe process group if calibration times out;
+- the optional `glm52-exl3` profile builds the EXL3 extension from its pinned
+  public source and exposes the Trellis MoE path without a binary ABI shim.
 
 Historical comparison data remains on [v18](glm5.2_v18.md), while the DCP
 optimization background remains on [v19](glm5.2_v19.md). This page is
@@ -32,14 +34,14 @@ stated GG and SparkInfer base commits.
 ## Release Image
 
 ```text
-voipmonitor/vllm:gilded-gnosis-v20-vllm99287e8-si4ecc87f-fi801d57a-cu132-20260728-r5
-Docker manifest: sha256:006e293e9e16dbe4416f259b43132a29e1078c62b0956886eb12c3186bcb433b
-Local image ID: sha256:5913c05c5f8ce3053852a8d6b02607d70425bec9386a40c72b75710d0ee3c6bf
+voipmonitor/vllm:gilded-gnosis-v20-vllm936ed48-sif532ec9-fi801d57a-cu132-20260728-r5
+Docker manifest: sha256:473e4c5a6a3795ee48a8f50493f9628f7c53f449d5a512f5cc04add77693044c
+Local image ID: sha256:178fe7439b3a83f6dc78259dc36bfbedfa9f85f1d79ef1b5551eb4940cf32e42
 ```
 
 This supersedes all earlier v20 candidates. The registry manifest is the exact
-24,834,713,882-byte local image used for the serialized release gates below;
-there was no rebuild between testing and push. Both final source trees were
+24,930,661,390-byte local image used for the final helper and runtime-contract
+gates below; there was no rebuild between those gates and push. Both source trees were
 composed from clean public bases plus exact public PR heads. The generated
 integration patches and lockfiles are public, immutable release artifacts;
 there is no private overlay or source bind mount.
@@ -52,9 +54,10 @@ Pinned source stack:
 | Component | Ref / commit |
 |---|---|
 | Canonical GG base | `local-inference-lab/vllm dev/gilded-gnosis` @ `4247d6765398fd42de3c108a8d991b2634fe88d1` |
-| Composed vLLM tree | `99287e8898587f536b5710e25d1b65229f1d6d78` |
+| Composed vLLM tree | `936ed4829ed6b6a34b9052a7a2614333ee3b2623` |
 | SparkInfer base | `local-inference-lab/sparkinfer master` @ `f9be2724953a5b412d19c20482aeb0a64fbd5d2a` |
-| Composed SparkInfer tree | `4ecc87fbe51090b7932e3ba8fa06d9649296ba38` |
+| Composed SparkInfer tree | `f532ec965a70b710ba45e6f751fe5d7135001108` |
+| EXL3 extension | `brandonmmusic-max/exllamav3 a1-retile-sm120` @ `704aefd743b390af4bd0fb429d1906f9b964c7d8` |
 | FlashInfer | `801d57a08958c13d375ddbb6be3be4808f48a708` |
 | CUTLASS C++ / DSL | `e6233cbac5d7c7a865c19c91cd684ceece19513c` / `4.6.0` |
 | InstantTensor | `85e7c5f5539d9c006ee0c26bc1b5233c65251b6b` |
@@ -62,9 +65,9 @@ Pinned source stack:
 | NCCL | local-inference `2.30.4` |
 | PyTorch / CUDA / loaded cuDNN | `2.12.0+cu132` / `13.2.1` / `9.20.0.48` |
 | CUDA system-base cuDNN packages | `9.22.0.52` |
-| Launcher source | `local-inference-lab/blackwell-llm-docker` @ `211141bc7ccb27f4753bf86f78e6686e07c6faa4` |
-| Validated build execution | `local-inference-lab/blackwell-llm-docker` @ `078987c8dee97dabc7d18b3ad298b77322b7a6af` |
-| Immutable reproduction recipe | `local-inference-lab/blackwell-llm-docker` @ `1c5f885220b897096745f97c98ad35adaae96e44` |
+| Launcher source | `local-inference-lab/blackwell-llm-docker` @ `a2129e983b07fbfaa5b872a1a0b25a07c3f01876` |
+| Validated build execution | `local-inference-lab/blackwell-llm-docker` @ `f1abd5c3ab38832b52625be9fe112801906e51ca` |
+| Immutable reproduction recipe | `local-inference-lab/blackwell-llm-docker` @ `1e4d0c7e7981046f65926235f02824d795691e57` |
 
 The image uses no `VLLM_PATCH_URL`, private source overlay, or source bind
 mount. It does contain generated `VLLM_PATCH_FILE` and SparkInfer patch
@@ -75,7 +78,7 @@ cache fingerprint derived from the pinned sources.
 ## Build It Exactly
 
 The canonical build entry point is
-[`build-gilded-gnosis-v20-final-cu132.sh`](https://github.com/local-inference-lab/blackwell-llm-docker/blob/1c5f885220b897096745f97c98ad35adaae96e44/build-gilded-gnosis-v20-final-cu132.sh).
+[`build-gilded-gnosis-v20-final-cu132.sh`](https://github.com/local-inference-lab/blackwell-llm-docker/blob/1e4d0c7e7981046f65926235f02824d795691e57/build-gilded-gnosis-v20-final-cu132.sh).
 The explicit reproduction mode uses archived, hash-verified locks and patches,
 then verifies that applying them to the pinned bases produces the exact trees
 above. It validates runtime symbols, helper contracts, and image labels before
@@ -84,7 +87,7 @@ allowing an optional push.
 ```bash
 git clone https://github.com/local-inference-lab/blackwell-llm-docker.git
 cd blackwell-llm-docker
-git checkout 1c5f885220b897096745f97c98ad35adaae96e44
+git checkout 1e4d0c7e7981046f65926235f02824d795691e57
 VLLM_RELEASE_COMPOSITION=reproduce-r5 \
   ./build-gilded-gnosis-v20-final-cu132.sh
 ```
@@ -118,7 +121,9 @@ on top of those bases:
 | vLLM | [#179](https://github.com/local-inference-lab/vllm/pull/179) | Add partial replicated-indexer topology and mixed target/draft grouping. |
 | vLLM | [#184](https://github.com/local-inference-lab/vllm/pull/184) | Dispatch lossless BF16 PCIe DMA above a measured byte crossover. |
 | vLLM | [#185](https://github.com/local-inference-lab/vllm/pull/185) | Gate DCP query split by a measured context crossover. |
+| vLLM | [#190](https://github.com/local-inference-lab/vllm/pull/190) | Add the EXL3 rank-sliced MoE integration and prefill planner. |
 | SparkInfer | [#81](https://github.com/local-inference-lab/sparkinfer/pull/81) | Measure lossless collective/overlap crossovers and derive a cached serving policy. |
+| SparkInfer | [#49](https://github.com/local-inference-lab/sparkinfer/pull/49) | Add the planned Trellis execution path used by EXL3. |
 
 The release build itself does not merge canonical branches and does not consume
 a precomposed integration branch. It generates both build-time patches from
@@ -155,7 +160,7 @@ script. Docker with NVIDIA Container Toolkit, host IPC, and at least four
 Blackwell GPUs is required. Pull the immutable image first:
 
 ```bash
-docker pull voipmonitor/vllm:gilded-gnosis-v20-vllm99287e8-si4ecc87f-fi801d57a-cu132-20260728-r5
+docker pull voipmonitor/vllm:gilded-gnosis-v20-vllm936ed48-sif532ec9-fi801d57a-cu132-20260728-r5
 ```
 
 Save the following as `compose.yml`. Bare environment entries pass a host
@@ -168,7 +173,7 @@ limit.
 ```yaml
 services:
   glm52:
-    image: voipmonitor/vllm:gilded-gnosis-v20-vllm99287e8-si4ecc87f-fi801d57a-cu132-20260728-r5
+    image: voipmonitor/vllm:gilded-gnosis-v20-vllm936ed48-sif532ec9-fi801d57a-cu132-20260728-r5
     entrypoint: ["/usr/local/bin/serve-gilded-gnosis.sh"]
     network_mode: host
     ipc: host
@@ -317,6 +322,10 @@ MOE_MODE=a16 TP=8 DCP=4 MTP=0 MAX_NUM_SEQS=32 GRAPH=128 \
 
 # NF3 hybrid. MODEL_FAMILY selects its TP4/A16/NVFP4-KV defaults.
 MODEL_FAMILY=glm52-hybrid DCP=4 MTP=3 docker compose up -d
+
+# Community EXL3 profile. The helper pins its tested checkpoint revision and
+# TP4/DCP4 defaults; full model performance validation remains community-run.
+MODEL_FAMILY=glm52-exl3 docker compose up -d
 ```
 
 For a local checkpoint, `MODEL` must use its in-container path below
@@ -328,13 +337,13 @@ revision `8a1f4a13204acf2b7ac840375efaed64c231c522`.
 
 | Variable | Default and meaning |
 |---|---|
-| `MODEL_FAMILY` | `glm52`; use `glm52-hybrid` for the TP4 NF3 preset. The unified image also accepts `ds4`. |
-| `MODEL` | Luke NVFP4 for `glm52`; the madeby561 NF3 checkpoint for `glm52-hybrid`; local paths are supported. |
+| `MODEL_FAMILY` | `glm52`; use `glm52-hybrid` for TP4 NF3 or `glm52-exl3` for the source-built EXL3/Trellis profile. The unified image also accepts `ds4`. |
+| `MODEL` | Luke NVFP4 for `glm52`; the madeby561 NF3 checkpoint for `glm52-hybrid`; the pinned Brandon EXL3 checkpoint for `glm52-exl3`; local paths are supported. |
 | `MODEL_REVISION` | Immutable tested Hugging Face revision. Set the correct revision when changing a remote `MODEL`. |
 | `SERVED_MODEL_NAME` | API model name; defaults to the selected checkpoint preset. |
-| `GPUS` | Ordered physical GPU list. Resolution is explicit `GPUS`, then existing `CUDA_VISIBLE_DEVICES`, then the preset default. Standard default is `0,1,2,3,4,5,6,7`; NF3 default is `0,1,2,3`. |
+| `GPUS` | Ordered physical GPU list. Resolution is explicit `GPUS`, then existing `CUDA_VISIBLE_DEVICES`, then the preset default. Standard default is `0,1,2,3,4,5,6,7`; NF3 and EXL3 default to `0,1,2,3`. |
 | `PORT` | `8000`. Host networking exposes it directly. |
-| `TP` | Standard `8`, virtual-sharded `6`, or NF3 `4`. |
+| `TP` | Standard `8`, virtual-sharded `6`, or NF3/EXL3 `4`. |
 | `DCP` | Decode context parallel size. `1` disables DCP communication; validated values are topology-dependent. |
 | `MTP` | `0` disables speculation. `3` is the principal validated speculative mode; the helper accepts an integer token count. |
 | `MAX_NUM_SEQS` | Standard `64`; scheduler concurrency and the input to automatic graph sizing. |
@@ -353,6 +362,7 @@ revision `8a1f4a13204acf2b7ac840375efaed64c231c522`.
 | `PCIE_CALIBRATION_CACHE_DIR` | Defaults below the active fingerprinted XDG cache, normally `/cache/jit/<fingerprint>/pcie-calibration`. |
 | `PCIE_DMA_MIN_BYTES` | `auto`, `off`, or an explicit byte/KiB/MiB threshold for lossless BF16 PCIe DMA dispatch. |
 | `DCP_QUERY_SPLIT_MIN_CONTEXT_TOKENS` | `auto` uses the measured crossover; an integer is an explicit minimum context. |
+| `DCP_CKV_GATHER_MAX_TOKENS` | `140000`; maximum pure-prefill size eligible for transient full-CKV gather. Raise explicitly for longer prefills, accepting the documented workspace cost. |
 
 Advanced A/B controls are `DCP_QUERY_SPLIT`, `DCP_CKV_GATHER`,
 `DCP_TOPK_OWNER_MERGE`, `DCP_INDEXER_SHARDS`, `DCP_CKV_PREFETCH_DEPTH`,
@@ -387,6 +397,7 @@ for selecting the serving memory budget.
 | `lukealonso/GLM-5.2-NVFP4` | `modelopt_fp4` | `a4` or `a16` | `none` or `mxfp8` |
 | `festr2/GLM-5.2-BF16-AMDMXFP4experts` | `mxfp4` | `force-a8-experimental` | `none`, `mxfp8`, or `fp8` |
 | `madeby561/GLM-5.2-MXFP8-NVFP4-NF3-Hybrid` | `nvfp4_nf3_hybrid` | `a16` | `nf3-mxfp8` |
+| `brandonmusic/GLM-5.2-EXL3-TR3-3.0bpw` | `exl3` | `a16` / Trellis | none |
 
 For Luke NVFP4, A4 and A16 select the routed-expert activation path; they do
 not rewrite the NVFP4 checkpoint weights. A16 uses BF16 expert activations and
@@ -417,6 +428,8 @@ DCP_QUERY_SPLIT  -> VLLM_DCP_QUERY_SPLIT
 DCP_QUERY_SPLIT_MIN_CONTEXT_TOKENS
                  -> VLLM_DCP_QUERY_SPLIT_MIN_CONTEXT_TOKENS
 DCP_CKV_GATHER   -> VLLM_B12X_MLA_CKV_GATHER
+DCP_CKV_GATHER_MAX_TOKENS
+                 -> VLLM_B12X_MLA_CKV_GATHER_MAX_TOKENS
 DCP_TOPK_OWNER_MERGE -> VLLM_DCP_TOPK_OWNER_MERGE
 DCP_INDEXER_SHARDS   -> VLLM_DCP_INDEXER_SHARDS
 DCP_CKV_PREFETCH_DEPTH -> VLLM_B12X_MLA_CKV_PREFETCH_DEPTH
@@ -442,6 +455,47 @@ integers. The static eligibility mapping is:
 `2` creates a measured partial `2x2` topology; at TP8/DCP8, `4` creates `2x4`.
 The CKV cache remains sharded by the full DCP size. The query-split flag at
 DCP1 does not create inter-rank DCP traffic.
+
+#### Full-CKV gather capacity
+
+Full-CKV gather is a pure-prefill optimization. It gathers each layer's
+compressed CKV once so every DCP rank can run its local attention heads over
+the complete context. It replaces the more communication-heavy fallback chain
+for that prefill. It does not affect DCP1, decode, mixed prefill/decode batches,
+CUDA graph capture, or virtual TP6. The validated automatic geometries are
+TP4/DCP2,4 and TP8/DCP2,4,8.
+
+The source default is 524,288 tokens. An older external EXL3 recipe overrode
+it to 16,384, which silently forced 64k and 128k prefills onto the fallback.
+The release helper now sets and prints an explicit balanced default of 140,000:
+large enough for the published 8k/64k/128k matrix while reserving much less
+workspace than the source default. This preserves the historical correctly
+configured v20 throughput; it is not a new 40-90% gain over that baseline.
+
+Matched TP8/MTP0/A4/FP8-KV A/B runs on the r5 source stack demonstrate the
+regression prevented by the explicit policy. Values are client prefill tok/s:
+
+| DCP | Capacity | 8k | 64k | 128k | Global KV budget |
+|---:|---:|---:|---:|---:|---:|
+| 2 | 16,384 | 5,874 | 5,275 | 5,182 | 1,250,176 |
+| 2 | 140,000 | 5,878 | 5,828 | 5,561 | 1,245,696 |
+| 4 | 16,384 | 5,884 | 4,045 | 4,170 | 2,377,984 |
+| 4 | 140,000 | 5,875 | 5,891 | 5,654 | 2,370,816 |
+| 8 | 16,384 | 5,607 | 3,066 | 2,877 | 4,699,136 |
+| 8 | 140,000 | 5,614 | 5,644 | 5,463 | 4,686,336 |
+
+The 16,384 rows are deliberately forced negative controls, not the historical
+v20 baseline. Correctly configured TP8/DCP4 had already measured about
+5.6-5.85k tok/s before r5; the explicit 140k helper default prevents an old
+external override from silently losing that established fast path.
+
+At prefetch depth 0 and one execution lane, the 140k FP8-KV workspace is
+approximately 131.4 MiB/GPU for DCP2, 109.5 MiB for DCP4, and 98.7 MiB for
+DCP8. MTP and CKV prefetch may require additional lanes, so the startup log is
+the authoritative reservation. To retain full gather for a 400k campaign,
+set `DCP_CKV_GATHER_MAX_TOKENS` above that exact prompt size and re-check the
+reported KV budget. Setting only the low-level `VLLM_*` alias is also accepted,
+but the helper-facing name is preferred.
 
 #### Lossless calibration
 
@@ -671,7 +725,7 @@ indistinguishable from ignoring none: the mean changes by only `-0.0000312`
 (`-0.05%`, `p` approximately `0.97`) while consuming about `1.22 GiB/GPU`.
 Therefore the current helper source no longer excludes `kv_b_proj` by default.
 The corrected launcher is
-[`serve-glm52-v16.sh`](https://github.com/local-inference-lab/blackwell-llm-docker/blob/2993b2c02f4f00d562451105de740130d90da4a0/launchers/serve-glm52-v16.sh).
+[`serve-glm52-v19.sh`](https://github.com/local-inference-lab/blackwell-llm-docker/blob/a2129e983b07fbfaa5b872a1a0b25a07c3f01876/launchers/serve-glm52-v19.sh).
 
 Keeping only the fused q/kv-a pair in BF16 is an optional quality experiment.
 Its aggregate mean was 1.87% lower than the old `kv_b_proj`-only preset;
@@ -805,8 +859,28 @@ Raw final artifacts are under:
 
 ### Clean r5 release gates
 
-The exact pushed r5 image was started through the embedded helper on GPUs
-0-7. Model loading and graph capture completed before any client started.
+The broad concurrency gates below were run through the embedded helper on the
+immediately preceding clean r5 candidate. Model loading and graph capture
+completed before any client started. The final image adds the isolated EXL3
+integration and explicit 140k full-CKV policy; its standard GLM path is gated
+separately below rather than silently attributing the older measurements to a
+different image ID.
+
+The exact pushed digest was then started on GPUs 8-15, the slightly slower GPU
+group on this host. Both DCP1 runs completed without request errors, and the
+DCP4 log confirmed query split, partial `2x2` indexer replication, owner merge,
+native CKV prefetch depth 1, and transient full-CKV gather at the printed 140k
+capacity.
+
+| Final-image gate | Result |
+|---|---:|
+| TP8/DCP1/MTP0 A16 decode, run 1 | `86.656` aggregate / `87.352` active tok/s |
+| TP8/DCP1/MTP0 A16 decode, run 2 | `86.553` aggregate / `87.268` active tok/s |
+| TP8/DCP4/MTP0 A16 exact 64k prefill | `5,685 tok/s`; `11.528 s` TTFT |
+| Reported global KV budget | DCP1 `682,816`; DCP4 `2,379,520` tokens |
+
+These values validate the final image on that GPU group; use the retained
+GPU0-7 tables below for like-for-like historical performance comparisons.
 
 | Gate | Configuration | Result |
 |---|---|---:|
@@ -976,7 +1050,7 @@ resumable v18/v19 runner. Install the benchmark client at
 ```bash
 git clone https://github.com/local-inference-lab/rtx6kpro.git
 cd rtx6kpro
-docker pull voipmonitor/vllm:gilded-gnosis-v20-vllm99287e8-si4ecc87f-fi801d57a-cu132-20260728-r5
+docker pull voipmonitor/vllm:gilded-gnosis-v20-vllm936ed48-sif532ec9-fi801d57a-cu132-20260728-r5
 
 # Complete 40-case historical-compatible campaign. Existing completed cases
 # under RESULT_ROOT are skipped only when both summary.json and complete exist.

--- a/models/glm5.2_v20.md
+++ b/models/glm5.2_v20.md
@@ -18,7 +18,9 @@ measured DCP prefill topology:
   Compose leaves `GPUS` empty, allows 600 seconds for a cold probe, and
   terminates the complete probe process group if calibration times out;
 - the optional `glm52-exl3` profile builds the EXL3 extension from its pinned
-  public source and exposes the Trellis MoE path without a binary ABI shim.
+  public source and exposes the Trellis MoE path without a binary ABI shim;
+- r6 adds an opt-in, DCP-aware LMCache 0.5.2 prefix-offload path with RAM-only
+  and buffered-filesystem modes while leaving ordinary serving unchanged.
 
 Historical comparison data remains on [v18](glm5.2_v18.md), while the DCP
 optimization background remains on [v19](glm5.2_v19.md). This page is
@@ -34,13 +36,13 @@ stated GG and SparkInfer base commits.
 ## Release Image
 
 ```text
-voipmonitor/vllm:gilded-gnosis-v20-vllm936ed48-sif532ec9-fi801d57a-cu132-20260728-r5
-Docker manifest: sha256:473e4c5a6a3795ee48a8f50493f9628f7c53f449d5a512f5cc04add77693044c
-Local image ID: sha256:178fe7439b3a83f6dc78259dc36bfbedfa9f85f1d79ef1b5551eb4940cf32e42
+voipmonitor/vllm:gilded-gnosis-v20-vllm936ed48-sif532ec9-fi801d57a-cu132-20260728-r6
+Docker manifest: sha256:3000c2c917ba402ae7784a6549fb458722b0f689d715ca9e5f22d18e0fa9e1bd
+Local image ID: sha256:d4bcd6185a368b1207a2c85290522ddabf9b6fa2eb5ca398b30b29addbec291d
 ```
 
 This supersedes all earlier v20 candidates. The registry manifest is the exact
-24,930,661,390-byte local image used for the final helper and runtime-contract
+25,200,908,897-byte local image used for the final helper and runtime-contract
 gates below; there was no rebuild between those gates and push. Both source trees were
 composed from clean public bases plus exact public PR heads. The generated
 integration patches and lockfiles are public, immutable release artifacts;
@@ -61,13 +63,14 @@ Pinned source stack:
 | FlashInfer | `801d57a08958c13d375ddbb6be3be4808f48a708` |
 | CUTLASS C++ / DSL | `e6233cbac5d7c7a865c19c91cd684ceece19513c` / `4.6.0` |
 | InstantTensor | `85e7c5f5539d9c006ee0c26bc1b5233c65251b6b` |
+| LMCache | upstream `v0.5.2` @ `cd2c0d6a6a982ec5e334bae7704e1029c06d3c97`, wheel `0.5.2+glm52dcp.2` |
 | DeepGEMM | `a6b593d2826719dcf4892609af7b84ee23aaf32a` |
 | NCCL | local-inference `2.30.4` |
 | PyTorch / CUDA / loaded cuDNN | `2.12.0+cu132` / `13.2.1` / `9.20.0.48` |
 | CUDA system-base cuDNN packages | `9.22.0.52` |
-| Launcher source | `local-inference-lab/blackwell-llm-docker` @ `a2129e983b07fbfaa5b872a1a0b25a07c3f01876` |
-| Validated build execution | `local-inference-lab/blackwell-llm-docker` @ `f1abd5c3ab38832b52625be9fe112801906e51ca` |
-| Immutable reproduction recipe | `local-inference-lab/blackwell-llm-docker` @ `1e4d0c7e7981046f65926235f02824d795691e57` |
+| Launcher source | `local-inference-lab/blackwell-llm-docker` @ `467e41ac408ac0a37719ffdae0f7b1707f8939b5` |
+| Validated build-equivalent tree | `local-inference-lab/blackwell-llm-docker` @ `3382b26d13017112cc6c52753dddd1d0f1d07955` |
+| Immutable reproduction recipe | `local-inference-lab/blackwell-llm-docker` @ `fdca0230e5860cce0cef65a85de0737ab22f34bd` |
 
 The image uses no `VLLM_PATCH_URL`, private source overlay, or source bind
 mount. It does contain generated `VLLM_PATCH_FILE` and SparkInfer patch
@@ -78,7 +81,7 @@ cache fingerprint derived from the pinned sources.
 ## Build It Exactly
 
 The canonical build entry point is
-[`build-gilded-gnosis-v20-final-cu132.sh`](https://github.com/local-inference-lab/blackwell-llm-docker/blob/1e4d0c7e7981046f65926235f02824d795691e57/build-gilded-gnosis-v20-final-cu132.sh).
+[`build-gilded-gnosis-v20-final-cu132.sh`](https://github.com/local-inference-lab/blackwell-llm-docker/blob/fdca0230e5860cce0cef65a85de0737ab22f34bd/build-gilded-gnosis-v20-final-cu132.sh).
 The explicit reproduction mode uses archived, hash-verified locks and patches,
 then verifies that applying them to the pinned bases produces the exact trees
 above. It validates runtime symbols, helper contracts, and image labels before
@@ -87,16 +90,18 @@ allowing an optional push.
 ```bash
 git clone https://github.com/local-inference-lab/blackwell-llm-docker.git
 cd blackwell-llm-docker
-git checkout 1e4d0c7e7981046f65926235f02824d795691e57
-VLLM_RELEASE_COMPOSITION=reproduce-r5 \
+git checkout fdca0230e5860cce0cef65a85de0737ab22f34bd
+VLLM_RELEASE_COMPOSITION=reproduce-r6 \
   ./build-gilded-gnosis-v20-final-cu132.sh
 ```
 
 For a new release candidate, omit `VLLM_RELEASE_COMPOSITION`. The default
 always resolves the current clean GG and SparkInfer bases, composes the exact
 versioned PR manifests, and fails if either base or any PR head moves during
-the build. The review for this composer, archived r5 source artifacts, and
-their tests is [blackwell-llm-docker #7](https://github.com/local-inference-lab/blackwell-llm-docker/pull/7).
+the build. The clean composer and archived source artifacts are reviewed in
+[blackwell-llm-docker #7](https://github.com/local-inference-lab/blackwell-llm-docker/pull/7);
+the r6 LMCache build, helper, tests, and reproduction mode are reviewed in
+[blackwell-llm-docker #8](https://github.com/local-inference-lab/blackwell-llm-docker/pull/8).
 
 The build deliberately excludes the separate weight-lifetime experiments in
 vLLM PR #154, vLLM PR #157, and SparkInfer PR #62. It also excludes the
@@ -124,11 +129,13 @@ on top of those bases:
 | vLLM | [#190](https://github.com/local-inference-lab/vllm/pull/190) | Add the EXL3 rank-sliced MoE integration and prefill planner. |
 | SparkInfer | [#81](https://github.com/local-inference-lab/sparkinfer/pull/81) | Measure lossless collective/overlap crossovers and derive a cached serving policy. |
 | SparkInfer | [#49](https://github.com/local-inference-lab/sparkinfer/pull/49) | Add the planned Trellis execution path used by EXL3. |
+| LMCache | [local fork #1](https://github.com/local-inference-lab/LMCache/pull/1) | Add exact MLA+DCP object geometry, reader locking, physical block expansion, and chunked-store event lifetime to v0.5.2. |
 
 The release build itself does not merge canonical branches and does not consume
 a precomposed integration branch. It generates both build-time patches from
 the clean bases and manifests, verifies their result trees, and archives the
-exact r5 artifacts. SparkInfer #76 is closed and is not an additional release
+exact r5 compute-stack artifacts. r6 additionally builds the hash-pinned
+LMCache source diff above into a CUDA-enabled wheel. SparkInfer #76 is closed and is not an additional release
 delta: the resulting PCIe output-lifetime implementation matches the pinned
 master. There is no runtime source patching or source bind mount.
 
@@ -160,7 +167,7 @@ script. Docker with NVIDIA Container Toolkit, host IPC, and at least four
 Blackwell GPUs is required. Pull the immutable image first:
 
 ```bash
-docker pull voipmonitor/vllm:gilded-gnosis-v20-vllm936ed48-sif532ec9-fi801d57a-cu132-20260728-r5
+docker pull voipmonitor/vllm:gilded-gnosis-v20-vllm936ed48-sif532ec9-fi801d57a-cu132-20260728-r6
 ```
 
 Save the following as `compose.yml`. Bare environment entries pass a host
@@ -173,7 +180,7 @@ limit.
 ```yaml
 services:
   glm52:
-    image: voipmonitor/vllm:gilded-gnosis-v20-vllm936ed48-sif532ec9-fi801d57a-cu132-20260728-r5
+    image: voipmonitor/vllm:gilded-gnosis-v20-vllm936ed48-sif532ec9-fi801d57a-cu132-20260728-r6
     entrypoint: ["/usr/local/bin/serve-gilded-gnosis.sh"]
     network_mode: host
     ipc: host
@@ -232,6 +239,18 @@ services:
       - NF3_GRID188
       - LOAD_FORMAT
       - INSTANTTENSOR_BACKEND
+      - LMCACHE_MODE
+      - LMCACHE_L1_GB
+      - LMCACHE_L1_INIT_GB
+      - LMCACHE_L2_PATH
+      - LMCACHE_L2_GB
+      - LMCACHE_L2_WORKERS
+      - LMCACHE_CHUNK_SIZE
+      - LMCACHE_MAX_GPU_WORKERS
+      - LMCACHE_MAX_CPU_WORKERS
+      - LMCACHE_PORT
+      - LMCACHE_HTTP_PORT
+      - LMCACHE_PROMETHEUS_PORT
       - PYTORCH_CUDA_ALLOC_CONF
       - DRY_RUN
     volumes:
@@ -320,6 +339,16 @@ MODEL=/root/models/GLM-5.2-BF16-AMDMXFP4experts \
 MOE_MODE=a16 TP=8 DCP=4 MTP=0 MAX_NUM_SEQS=32 GRAPH=128 \
   MAX_BATCHED_TOKENS=8192 docker compose up -d
 
+# Add a 24 GiB host-RAM prefix cache. Ordinary GPU KV remains managed by vLLM.
+LMCACHE_MODE=ram LMCACHE_L1_GB=24 MOE_MODE=a16 TP=8 DCP=4 \
+  MTP=0 docker compose up -d
+
+# RAM front tier plus persistent buffered filesystem/NVMe tier. The default
+# path is already covered by the Compose /cache volume.
+LMCACHE_MODE=disk LMCACHE_L1_GB=8 LMCACHE_L2_GB=512 \
+  LMCACHE_L2_PATH=/cache/lmcache/8000 MOE_MODE=a16 TP=8 DCP=4 \
+  MTP=0 docker compose up -d
+
 # NF3 hybrid. MODEL_FAMILY selects its TP4/A16/NVFP4-KV defaults.
 MODEL_FAMILY=glm52-hybrid DCP=4 MTP=3 docker compose up -d
 
@@ -363,6 +392,11 @@ revision `8a1f4a13204acf2b7ac840375efaed64c231c522`.
 | `PCIE_DMA_MIN_BYTES` | `auto`, `off`, or an explicit byte/KiB/MiB threshold for lossless BF16 PCIe DMA dispatch. |
 | `DCP_QUERY_SPLIT_MIN_CONTEXT_TOKENS` | `auto` uses the measured crossover; an integer is an explicit minimum context. |
 | `DCP_CKV_GATHER_MAX_TOKENS` | `140000`; maximum pure-prefill size eligible for transient full-CKV gather. Raise explicitly for longer prefills, accepting the documented workspace cost. |
+| `LMCACHE_MODE` | `off`; `ram` enables host-RAM prefix offload and `disk` adds a buffered filesystem tier. Supported by the `glm52` and `glm52-hybrid` helpers, not DS4 or EXL3. |
+| `LMCACHE_L1_GB` / `LMCACHE_L1_INIT_GB` | RAM-cache maximum and initial allocation, both `24` GiB by default when LMCache is enabled. |
+| `LMCACHE_L2_PATH` / `LMCACHE_L2_GB` | Disk mode defaults to `/cache/lmcache/<PORT>` and `256` GiB. Keep `/cache` on persistent storage. |
+| `LMCACHE_CHUNK_SIZE` | Auto: `384` for DCP3/DCP6 and `512` otherwise. Override only with a value aligned to every effective cache block. |
+| `LMCACHE_MAX_GPU_WORKERS` | Defaults to `TP`; every TP rank is a GPU transfer client even when DCP is 1. |
 
 Advanced A/B controls are `DCP_QUERY_SPLIT`, `DCP_CKV_GATHER`,
 `DCP_TOPK_OWNER_MERGE`, `DCP_INDEXER_SHARDS`, `DCP_CKV_PREFETCH_DEPTH`,
@@ -389,6 +423,36 @@ reported 641,088 KV tokens, but the same 240k request OOMed when an unprofiled
 Inductor buffer requested another 64 MiB with only 66.38 MiB physically free.
 This is why successful startup and reported KV capacity alone are insufficient
 for selecting the serving memory budget.
+
+### LMCache Prefix Offload
+
+LMCache is opt-in. With `LMCACHE_MODE=off`, the helper executes the same model
+command as r5 and does not start an LMCache process or change allocator
+settings. `ram` starts one in-container LMCache MP server backed by host RAM.
+`disk` adds the native filesystem adapter with `use_odirect=false`, so reads can
+come from the Linux page cache when resident and from the underlying NVMe when
+not resident.
+
+The r6 patch is required because MLA+DCP does not have TP-only cache geometry.
+For example, TP8/DCP4 stores four sequence-shard objects, each consumed by two
+query-parallel ranks. The connector now carries that exact reader count,
+mirrors replicated and partially replicated KV groups, expands manager block
+IDs into physical kernel blocks where required, and retains every asynchronous
+chunk-store future and CUDA IPC event until completion. No FP8/I8 compression
+is applied to LMCache data by this feature.
+
+When enabled, the wrapper sets `PYTORCH_CUDA_ALLOC_CONF` to
+`expandable_segments:False`: LMCache registers KV storage by virtual address,
+and expandable segments are incompatible with that contract. Other allocator
+options are preserved. Recheck the desired long-context memory budget when
+enabling LMCache rather than assuming the ordinary-serving KV number is
+unchanged.
+
+Startup must print `LMCache ready` before vLLM begins loading. A repeated exact
+prompt reports the restored token count under
+`usage.prompt_tokens_details.cached_tokens`. For multiple services, give each
+one unique model, LMCache, HTTP, and Prometheus ports; services on standard
+ports `8000+N` derive non-conflicting defaults automatically.
 
 ### Checkpoint And Quantization Modes
 
@@ -825,6 +889,27 @@ no benchmark overlapped another model load. The 2026-07-27 gate adds MTP3 and
 batched correctness coverage for the final runtime-stride image. The retained
 2026-07-26 comparison immediately below it is MTP0.
 
+### Final 2026-07-28 r6 LMCache gates
+
+The clean pushed r6 image was started through the embedded helper on both GPU
+groups. DCP1 used GPUs 0-7 and DCP4 used GPUs 8-15; both servers were healthy
+before either client ran. Cold and hit responses were greedy and produced the
+same SHA-256 output hash.
+
+| Gate | Cold result | Cache-hit result |
+|---|---|---|
+| TP8/DCP1 RAM, 8,192-token prompt | `0` cached, `2.287 s` | `8,192` cached, `0.144 s` |
+| TP8/DCP4 RAM, 8,192-token prompt | `0` cached, `2.433 s` | `8,192` cached, `0.156 s` |
+| TP8/DCP1 buffered disk, cold restart | stored 12,800 tokens | restored all 12,800 tokens; identical output |
+| TP8/DCP4 buffered disk, cold restart | four DCP writers stored 12,800 tokens | restored all 12,800 tokens; identical output |
+
+Additional overlay-before-clean-image gates covered TP6/DCP3 and TP6/DCP6 at
+12,288 tokens with the 384-token chunk geometry. TP8/DCP1/MTP3 also passed
+4+4 and 8+8 concurrent cold/hit requests without malformed output. Build-time
+tests ran against the installed CUDA wheel, not an unbuilt source checkout.
+The vLLM and SparkInfer result trees are unchanged from r5, so the retained
+compute-performance tables below remain the relevant speed baseline.
+
 ### Final 2026-07-27 candidate
 
 | Gate | Configuration | Result |
@@ -1050,7 +1135,7 @@ resumable v18/v19 runner. Install the benchmark client at
 ```bash
 git clone https://github.com/local-inference-lab/rtx6kpro.git
 cd rtx6kpro
-docker pull voipmonitor/vllm:gilded-gnosis-v20-vllm936ed48-sif532ec9-fi801d57a-cu132-20260728-r5
+docker pull voipmonitor/vllm:gilded-gnosis-v20-vllm936ed48-sif532ec9-fi801d57a-cu132-20260728-r6
 
 # Complete 40-case historical-compatible campaign. Existing completed cases
 # under RESULT_ROOT are skipped only when both summary.json and complete exist.

--- a/models/glm5.2_v20.md
+++ b/models/glm5.2_v20.md
@@ -32,15 +32,17 @@ stated GG and SparkInfer base commits.
 ## Release Image
 
 ```text
-voipmonitor/vllm:gilded-gnosis-v20-vllm0c79e41-sic3828fd-fi801d57a-cu132-20260727-r4
-Docker manifest: sha256:000d803130fe0e9ee45568835868c051ad9764a9c8650fec0e31885c8fc364bc
-Local image ID: sha256:6d42148768818bb5919ad7c960a18d13ba2e9508636c0d4f413d6aa2323e941f
+voipmonitor/vllm:gilded-gnosis-v20-vllm99287e8-si4ecc87f-fi801d57a-cu132-20260728-r5
+Docker manifest: sha256:006e293e9e16dbe4416f259b43132a29e1078c62b0956886eb12c3186bcb433b
+Local image ID: sha256:5913c05c5f8ce3053852a8d6b02607d70425bec9386a40c72b75710d0ee3c6bf
 ```
 
 This supersedes all earlier v20 candidates. The registry manifest is the exact
-24,834,261,803-byte local image used for the serialized release gates below;
-there was no rebuild between testing and push. The final source tree is a
-conflict-free merge of the public PR heads and contains no private patch.
+24,834,713,882-byte local image used for the serialized release gates below;
+there was no rebuild between testing and push. Both final source trees were
+composed from clean public bases plus exact public PR heads. The generated
+integration patches and lockfiles are public, immutable release artifacts;
+there is no private overlay or source bind mount.
 
 `si` identifies SparkInfer, the renamed B12X project. Legacy B12X environment
 variable names remain accepted for compatibility.
@@ -49,10 +51,10 @@ Pinned source stack:
 
 | Component | Ref / commit |
 |---|---|
-| Canonical GG base | `local-inference-lab/vllm dev/gilded-gnosis` @ `89b4a98d1ffebb2dda1e1ac5e55238e3a9cfbd58` |
-| vLLM release source | `voipmonitor/vllm build/gilded-gnosis-v20-pcie-auto-20260726` @ `0c79e41db41f250ccdfc4be92d171960a5787f73` |
-| SparkInfer base | `local-inference-lab/sparkinfer master` @ `f06881a22154e9573d0627b7b1d8b1014b351690` |
-| SparkInfer release source | `local-inference-lab/sparkinfer build/sparkinfer-v20-runtime-stride-20260727` @ `c3828fd7f807ce237a9ac36ef033659e6f6b6dd3` |
+| Canonical GG base | `local-inference-lab/vllm dev/gilded-gnosis` @ `4247d6765398fd42de3c108a8d991b2634fe88d1` |
+| Composed vLLM tree | `99287e8898587f536b5710e25d1b65229f1d6d78` |
+| SparkInfer base | `local-inference-lab/sparkinfer master` @ `f9be2724953a5b412d19c20482aeb0a64fbd5d2a` |
+| Composed SparkInfer tree | `4ecc87fbe51090b7932e3ba8fa06d9649296ba38` |
 | FlashInfer | `801d57a08958c13d375ddbb6be3be4808f48a708` |
 | CUTLASS C++ / DSL | `e6233cbac5d7c7a865c19c91cd684ceece19513c` / `4.6.0` |
 | InstantTensor | `85e7c5f5539d9c006ee0c26bc1b5233c65251b6b` |
@@ -60,29 +62,38 @@ Pinned source stack:
 | NCCL | local-inference `2.30.4` |
 | PyTorch / CUDA / loaded cuDNN | `2.12.0+cu132` / `13.2.1` / `9.20.0.48` |
 | CUDA system-base cuDNN packages | `9.22.0.52` |
-| Launcher source | `local-inference-lab/blackwell-llm-docker` @ `5a73c6790ba0aea041c1fe43144fcba28a606021` |
-| Build recipe | `local-inference-lab/blackwell-llm-docker` @ `a6211fa7992f2b4b7f1478e600e92c3d4ddbad4c` |
+| Launcher source | `local-inference-lab/blackwell-llm-docker` @ `211141bc7ccb27f4753bf86f78e6686e07c6faa4` |
+| Validated build execution | `local-inference-lab/blackwell-llm-docker` @ `078987c8dee97dabc7d18b3ad298b77322b7a6af` |
+| Immutable reproduction recipe | `local-inference-lab/blackwell-llm-docker` @ `1c5f885220b897096745f97c98ad35adaae96e44` |
 
-The image contains no `VLLM_PATCH_URL`, `VLLM_PATCH_FILE`, source bind mount,
-or private source overlay. Image labels expose every source pin and a cache
-fingerprint derived from the vLLM and SparkInfer commits.
+The image uses no `VLLM_PATCH_URL`, private source overlay, or source bind
+mount. It does contain generated `VLLM_PATCH_FILE` and SparkInfer patch
+artifacts derived solely from the public manifests. Image labels expose both
+base commits, every PR head, both result trees, patch and lock hashes, and a
+cache fingerprint derived from the pinned sources.
 
 ## Build It Exactly
 
 The canonical build entry point is
-[`build-gilded-gnosis-v20-final-cu132.sh`](https://github.com/local-inference-lab/blackwell-llm-docker/blob/a6211fa7992f2b4b7f1478e600e92c3d4ddbad4c/build-gilded-gnosis-v20-final-cu132.sh).
-It builds with the exact commits above, validates runtime symbols and source
-contracts, verifies the image labels, and only then allows an optional push.
+[`build-gilded-gnosis-v20-final-cu132.sh`](https://github.com/local-inference-lab/blackwell-llm-docker/blob/1c5f885220b897096745f97c98ad35adaae96e44/build-gilded-gnosis-v20-final-cu132.sh).
+The explicit reproduction mode uses archived, hash-verified locks and patches,
+then verifies that applying them to the pinned bases produces the exact trees
+above. It validates runtime symbols, helper contracts, and image labels before
+allowing an optional push.
 
 ```bash
 git clone https://github.com/local-inference-lab/blackwell-llm-docker.git
 cd blackwell-llm-docker
-git checkout a6211fa7992f2b4b7f1478e600e92c3d4ddbad4c
-PUSH_IMAGE=1 ./build-gilded-gnosis-v20-final-cu132.sh
+git checkout 1c5f885220b897096745f97c98ad35adaae96e44
+VLLM_RELEASE_COMPOSITION=reproduce-r5 \
+  ./build-gilded-gnosis-v20-final-cu132.sh
 ```
 
-The review for the build, embedded helper, calibrator, and their tests is
-[blackwell-llm-docker #6](https://github.com/local-inference-lab/blackwell-llm-docker/pull/6).
+For a new release candidate, omit `VLLM_RELEASE_COMPOSITION`. The default
+always resolves the current clean GG and SparkInfer bases, composes the exact
+versioned PR manifests, and fails if either base or any PR head moves during
+the build. The review for this composer, archived r5 source artifacts, and
+their tests is [blackwell-llm-docker #7](https://github.com/local-inference-lab/blackwell-llm-docker/pull/7).
 
 The build deliberately excludes the separate weight-lifetime experiments in
 vLLM PR #154, vLLM PR #157, and SparkInfer PR #62. It also excludes the
@@ -95,37 +106,32 @@ that selector policy was not part of this candidate or its validation.
 The cuBLAS/Xid correction is already in the pinned GG base through
 [vLLM PR #147](https://github.com/local-inference-lab/vllm/pull/147) and
 [SparkInfer PR #54](https://github.com/local-inference-lab/sparkinfer/pull/54).
-The release source adds these independently reviewable deltas:
+The pinned bases also already contain vLLM #177, #178, and #180 and
+SparkInfer #79 and #85. The clean r5 manifests apply only these exact PR heads
+on top of those bases:
 
 | Project | Review | Purpose |
 |---|---|---|
 | vLLM | [#145](https://github.com/local-inference-lab/vllm/pull/145) | Calibrated NVFP4 MLA KV outer-scale wiring. |
 | vLLM | [#172](https://github.com/local-inference-lab/vllm/pull/172) | Profile persistent kernel resources before allocating KV cache. |
 | vLLM | [#175](https://github.com/local-inference-lab/vllm/pull/175) | Split sparse prefill queries and reduce gathered result traffic. |
-| vLLM | [#177](https://github.com/local-inference-lab/vllm/pull/177) | Preallocate a bounded, memory-profiled CKV prefetch workspace. |
-| vLLM | [#178](https://github.com/local-inference-lab/vllm/pull/178) | Merge exact FP32 sparse top-k candidates by query-row owner. |
 | vLLM | [#179](https://github.com/local-inference-lab/vllm/pull/179) | Add partial replicated-indexer topology and mixed target/draft grouping. |
-| vLLM | [#180](https://github.com/local-inference-lab/vllm/pull/180) | Isolate the profiled MRV2 CUDA graph-pool lifecycle. |
 | vLLM | [#184](https://github.com/local-inference-lab/vllm/pull/184) | Dispatch lossless BF16 PCIe DMA above a measured byte crossover. |
 | vLLM | [#185](https://github.com/local-inference-lab/vllm/pull/185) | Gate DCP query split by a measured context crossover. |
-| SparkInfer | [#79](https://github.com/local-inference-lab/sparkinfer/pull/79) | Exchange exact FP32 DCP top-k candidates by owner without the generic staging path. |
 | SparkInfer | [#81](https://github.com/local-inference-lab/sparkinfer/pull/81) | Measure lossless collective/overlap crossovers and derive a cached serving policy. |
-| SparkInfer | [#85](https://github.com/local-inference-lab/sparkinfer/pull/85) | Pass the runtime page-table row stride to sparse-indexer kernels and use 64-bit offsets. |
 
-The release build itself does not merge canonical branches. Its exact
-integration branches contain only the GG/SparkInfer bases and the reviews
-listed above. SparkInfer #76 is closed and is not an additional release delta:
-the resulting PCIe output-lifetime implementation matches current master.
-There is no runtime patch file or source bind mount.
+The release build itself does not merge canonical branches and does not consume
+a precomposed integration branch. It generates both build-time patches from
+the clean bases and manifests, verifies their result trees, and archives the
+exact r5 artifacts. SparkInfer #76 is closed and is not an additional release
+delta: the resulting PCIe output-lifetime implementation matches the pinned
+master. There is no runtime source patching or source bind mount.
 
 ### Canonical Merge Status
 
 [Issue #33](https://github.com/local-inference-lab/rtx6kpro/issues/33) is the
-authoritative ordered merge checklist. As of 2026-07-27, all listed reviews are
-non-draft. vLLM #177, #178, and #180 plus SparkInfer #79 and #85 are already
-merged into their canonical bases; the remaining deltas stay independently
-reviewable. The image still pins the tested integration commits rather than
-moving source heads.
+authoritative ordered merge checklist. The image pins the exact base commits
+and additional PR heads above rather than following moving source refs.
 
 PR #145 is intentionally present in the image but is not requested for merge
 yet. The exact SparkInfer candidate-owner transport in
@@ -149,7 +155,7 @@ script. Docker with NVIDIA Container Toolkit, host IPC, and at least four
 Blackwell GPUs is required. Pull the immutable image first:
 
 ```bash
-docker pull voipmonitor/vllm:gilded-gnosis-v20-vllm0c79e41-sic3828fd-fi801d57a-cu132-20260727-r4
+docker pull voipmonitor/vllm:gilded-gnosis-v20-vllm99287e8-si4ecc87f-fi801d57a-cu132-20260728-r5
 ```
 
 Save the following as `compose.yml`. Bare environment entries pass a host
@@ -162,7 +168,7 @@ limit.
 ```yaml
 services:
   glm52:
-    image: voipmonitor/vllm:gilded-gnosis-v20-vllm0c79e41-sic3828fd-fi801d57a-cu132-20260727-r4
+    image: voipmonitor/vllm:gilded-gnosis-v20-vllm99287e8-si4ecc87f-fi801d57a-cu132-20260728-r5
     entrypoint: ["/usr/local/bin/serve-gilded-gnosis.sh"]
     network_mode: host
     ipc: host
@@ -526,10 +532,11 @@ and `{3,7}` to adjacent physical pairs `(0,1)`, `(2,3)`, `(4,5)`, and `(6,7)`.
 Replacing it with natural rank order makes those same logical pairs cross root
 complexes and invalidates the calibration result.
 
-A cold probe may compile kernels. v20 `r4` therefore raises the default timeout
-from 180 to 600 seconds. If it still expires, the helper terminates the complete
-`torchrun` process group before falling back; probe workers cannot remain on the
-GPUs and contend with the vLLM NCCL initialization that follows.
+A cold probe may compile kernels. v20 r4 raised the default timeout from 180
+to 600 seconds, and r5 retains that behavior. If it still expires, the helper
+terminates the complete `torchrun` process group before falling back; probe
+workers cannot remain on the GPUs and contend with the vLLM NCCL initialization
+that follows.
 
 Audit an intentionally ordered placement without loading model weights:
 
@@ -796,6 +803,32 @@ Raw final artifacts are under:
 /root/bench-results/glm52-v20-release-auto-gate-20260727/
 ```
 
+### Clean r5 release gates
+
+The exact pushed r5 image was started through the embedded helper on GPUs
+0-7. Model loading and graph capture completed before any client started.
+
+| Gate | Configuration | Result |
+|---|---|---:|
+| Decode run 1 | Luke NVFP4, TP8/DCP1/MTP0, A16, seq=1, graph=6 | `87.909` aggregate / `88.580` active tok/s |
+| Decode run 2 | Luke NVFP4, TP8/DCP1/MTP0, A16, seq=1, graph=6 | `87.845` aggregate / `88.548` active tok/s |
+| MTP decode | Luke NVFP4, TP8/DCP1/MTP3, A16, online MXFP8, seq=32, graph=128 | `162.933` aggregate / `163.397` active tok/s; acceptance `63.793%` |
+
+The MTP3 service then ran a deterministic 195-token ASCII correctness oracle
+with thinking disabled. C1, C4, C6, C8, C16, and C32 produced respectively
+`2/2`, `12/12`, `18/18`, `24/24`, `16/16`, and `32/32` byte-identical
+responses, with one unique output and no HTTP errors at every concurrency.
+This directly covers the earlier failure mode where output diverged above four
+parallel requests.
+
+Reported KV capacity was 682,816 tokens for the seq=1 MTP0 gate and 641,792
+tokens for the seq=32 MTP3 gate at `GPU_MEMORY_UTILIZATION=0.96`. Raw release
+artifacts are under:
+
+```text
+/root/bench-results/glm52-v20-r5-clean-20260728/
+```
+
 ### Retained 2026-07-26 MTP0 gate
 
 | Gate | Configuration | Result |
@@ -943,7 +976,7 @@ resumable v18/v19 runner. Install the benchmark client at
 ```bash
 git clone https://github.com/local-inference-lab/rtx6kpro.git
 cd rtx6kpro
-docker pull voipmonitor/vllm:gilded-gnosis-v20-vllm0c79e41-sic3828fd-fi801d57a-cu132-20260727-r4
+docker pull voipmonitor/vllm:gilded-gnosis-v20-vllm99287e8-si4ecc87f-fi801d57a-cu132-20260728-r5
 
 # Complete 40-case historical-compatible campaign. Existing completed cases
 # under RESULT_ROOT are skipped only when both summary.json and complete exist.
@@ -999,6 +1032,7 @@ backend markers needed to audit an outlier.
 The final validation artifacts on the release host are under:
 
 ```text
+/root/bench-results/glm52-v20-r5-clean-20260728
 /root/bench-results/glm52-v20-final-20260726/final-vllm0c79e41-sie603f74
 /root/bench-results/glm52-v20-dcp8-query-owner-matrix-20260727
 /root/bench-results/glm52-v20-release-auto-gate-20260727

--- a/scripts/bench-glm52-v20-validation.sh
+++ b/scripts/bench-glm52-v20-validation.sh
@@ -3,8 +3,8 @@ set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-export IMAGE='voipmonitor/vllm:gilded-gnosis-v20-vllm99287e8-si4ecc87f-fi801d57a-cu132-20260728-r5'
-export EXPECTED_IMAGE_ID='sha256:5913c05c5f8ce3053852a8d6b02607d70425bec9386a40c72b75710d0ee3c6bf'
+export IMAGE='voipmonitor/vllm:gilded-gnosis-v20-vllm936ed48-sif532ec9-fi801d57a-cu132-20260728-r5'
+export EXPECTED_IMAGE_ID='sha256:178fe7439b3a83f6dc78259dc36bfbedfa9f85f1d79ef1b5551eb4940cf32e42'
 export RESULT_ROOT="${RESULT_ROOT:-/root/bench-results/glm52-v20-validation-$(date -u +%Y%m%dT%H%M%SZ)}"
 export CACHE_A="${CACHE_A:-/root/.cache/vllm-glm52-release/slot-a}"
 export CACHE_B="${CACHE_B:-/root/.cache/vllm-glm52-release/slot-b}"

--- a/scripts/bench-glm52-v20-validation.sh
+++ b/scripts/bench-glm52-v20-validation.sh
@@ -3,8 +3,8 @@ set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-export IMAGE='voipmonitor/vllm:gilded-gnosis-v20-vllm0c79e41-sic3828fd-fi801d57a-cu132-20260727-r4'
-export EXPECTED_IMAGE_ID='sha256:6d42148768818bb5919ad7c960a18d13ba2e9508636c0d4f413d6aa2323e941f'
+export IMAGE='voipmonitor/vllm:gilded-gnosis-v20-vllm99287e8-si4ecc87f-fi801d57a-cu132-20260728-r5'
+export EXPECTED_IMAGE_ID='sha256:5913c05c5f8ce3053852a8d6b02607d70425bec9386a40c72b75710d0ee3c6bf'
 export RESULT_ROOT="${RESULT_ROOT:-/root/bench-results/glm52-v20-validation-$(date -u +%Y%m%dT%H%M%SZ)}"
 export CACHE_A="${CACHE_A:-/root/.cache/vllm-glm52-release/slot-a}"
 export CACHE_B="${CACHE_B:-/root/.cache/vllm-glm52-release/slot-b}"

--- a/scripts/bench-glm52-v20-validation.sh
+++ b/scripts/bench-glm52-v20-validation.sh
@@ -3,8 +3,8 @@ set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-export IMAGE='voipmonitor/vllm:gilded-gnosis-v20-vllm936ed48-sif532ec9-fi801d57a-cu132-20260728-r5'
-export EXPECTED_IMAGE_ID='sha256:178fe7439b3a83f6dc78259dc36bfbedfa9f85f1d79ef1b5551eb4940cf32e42'
+export IMAGE='voipmonitor/vllm:gilded-gnosis-v20-vllm936ed48-sif532ec9-fi801d57a-cu132-20260728-r6'
+export EXPECTED_IMAGE_ID='sha256:d4bcd6185a368b1207a2c85290522ddabf9b6fa2eb5ca398b30b29addbec291d'
 export RESULT_ROOT="${RESULT_ROOT:-/root/bench-results/glm52-v20-validation-$(date -u +%Y%m%dT%H%M%SZ)}"
 export CACHE_A="${CACHE_A:-/root/.cache/vllm-glm52-release/slot-a}"
 export CACHE_B="${CACHE_B:-/root/.cache/vllm-glm52-release/slot-b}"


### PR DESCRIPTION
## Summary

- pin v20 to the clean-composed r6 image, registry digest, image ID, and immutable reproduction commit;
- preserve the validated r5 vLLM/SparkInfer speed tables because r6 keeps those compute trees unchanged;
- document the opt-in LMCache 0.5.2 RAM and buffered-filesystem modes and every public configuration control;
- explain the MLA+DCP cache geometry, reader-lock, physical-block, and chunk-store lifetime fixes;
- publish clean-image DCP1/DCP4 cold and cache-hit validation plus TP6/DCP3/DCP6 and MTP3 concurrency gates;
- update the resumable validation wrapper to require the exact r6 image ID.

The clean image composer is reviewed in [blackwell-llm-docker #7](https://github.com/local-inference-lab/blackwell-llm-docker/pull/7). The r6 LMCache build and helper integration are reviewed in [blackwell-llm-docker #8](https://github.com/local-inference-lab/blackwell-llm-docker/pull/8). The LMCache source fix is isolated in [local-inference-lab/LMCache #1](https://github.com/local-inference-lab/LMCache/pull/1). The release checklist is [issue #33](https://github.com/local-inference-lab/rtx6kpro/issues/33).

## Final image

`voipmonitor/vllm:gilded-gnosis-v20-vllm936ed48-sif532ec9-fi801d57a-cu132-20260728-r6`

- Digest: `sha256:3000c2c917ba402ae7784a6549fb458722b0f689d715ca9e5f22d18e0fa9e1bd`
- ID: `sha256:d4bcd6185a368b1207a2c85290522ddabf9b6fa2eb5ca398b30b29addbec291d`
- LMCache is opt-in; `LMCACHE_MODE=off` preserves the r5 serving path.

## Checks

- `bash -n scripts/bench-glm52-v20-validation.sh`
- `git diff --check`
- clean-image TP8/DCP1 and TP8/DCP4 8,192-token cold/hit validation
- buffered-disk cold-restart validation at DCP1 and DCP4
- TP6/DCP3 and TP6/DCP6 12,288-token store/restore validation
- TP8/DCP1/MTP3 4+4 and 8+8 concurrent cold/hit correctness
- 34 focused geometry tests, 72 connector/adapter tests, 48 CUDA-manager tests, and installed-wheel build tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refreshed GLM-5.2 v20 (r5) release guide with updated vLLM image/tag/digest details, start/Compose commands, and pinned build references.
  * Expanded serving/calibration guidance (cold-probe 600s timeout behavior; DCP CKV gather controls; Full-CKV default 140k tokens and override workflow).
  * Added LMCache prefix offload configuration, updated checkpoint/quantization guidance (EXL3), adjusted Stable Controls defaults, and corrected the MXFP8 launcher reference.
  * Updated merge status text and added r6 LMCache + clean r5 release gates, including new validation artifact path.
* **Validation**
  * Updated the benchmark validation script to use the new r5 container image and expected pinned image digest.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->