### PR TITLE
feat(validation): salted needle-at-depth retrieval gate for release cases

### DIFF
--- a/scripts/bench-glm52-v18-validation.sh
+++ b/scripts/bench-glm52-v18-validation.sh
@@ -32,6 +32,9 @@ PREFILL_WARMUP_RUNS="${PREFILL_WARMUP_RUNS:-1}"
 PREFILL_REPEATS="${PREFILL_REPEATS:-3}"
 BETWEEN_RUNS_SECONDS="${BETWEEN_RUNS_SECONDS:-10}"
 TOKEN_TARGETING="${TOKEN_TARGETING:-estimate}"
+NEEDLE_GATE="${NEEDLE_GATE:-1}"
+NEEDLE_SIZES="${NEEDLE_SIZES:-8,64,96}"
+NEEDLE_REQUIRED_CLEAN_K="${NEEDLE_REQUIRED_CLEAN_K:-96}"
 SPARSE_MLA_FORCE_MQA="${SPARSE_MLA_FORCE_MQA:-0}"
 CUDA_ALLOC_CONF="${CUDA_ALLOC_CONF:-expandable_segments:True}"
 TP8_MAX_MODEL_LEN="${TP8_MAX_MODEL_LEN:-131072}"
@@ -237,6 +240,15 @@ text = result["choices"][0]["message"].get("reasoning") or result["choices"][0][
 assert text.strip() and text.count("!") < 16
 open(output, "w").write(json.dumps(result, indent=2) + "\n")
 PY
+
+  if [[ "${NEEDLE_GATE}" == 1 ]]; then
+    progress "NEEDLE case=${key} tp=${tp} dcp=${dcp} mtp=${mtp} sizes=${NEEDLE_SIZES}"
+    python3 "$(dirname "${BASH_SOURCE[0]}")/needle_gate.py" \
+      --host 127.0.0.1 --port "${port}" --model "${served}" \
+      --sizes "${NEEDLE_SIZES}" --required-clean-k "${NEEDLE_REQUIRED_CLEAN_K}" \
+      --output "${out}/needle-gate.json" > "${out}/needle-gate.log" 2>&1 \
+      || { cat "${out}/needle-gate.log"; echo "needle gate FAILED for case=${key}"; exit 1; }
+  fi
 
   progress "DECODE case=${key} tp=${tp} dcp=${dcp} mtp=${mtp}"
   docker logs "${name}" > "${out}/server.before-decode.log" 2>&1

--- a/scripts/needle_gate.py
+++ b/scripts/needle_gate.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Needle-at-depth qualification gate for GLM-5.2 serving images.
+
+Plants two labeled facts (5% and 95% positions) in synthetic prompts of
+increasing size and requires exact retrieval at temperature 0. Catches
+long-context KV/readout corruption that throughput benchmarks cannot see
+(a context-blind model benchmarks *faster*).
+
+Prompts are salted per invocation so no prefix cache (vLLM or LMCache L2)
+can serve KV computed by a previous run or a previous image. Without the
+salt, a broken engine can poison the shared LMCache disk cache and make a
+healthy image appear broken (or vice versa) on identical prompts.
+
+Born from the v20 r26 rejection (2026-08-03): r26 passed every speed cell,
+then lost the entire readout past ~98-128K tokens on TP4/DCP2. Run this
+against every new image/checkpoint/config before it goes near production.
+
+Usage:
+  python needle_gate.py --model GLM-5.2-EXL3-TR3-3.0bpw [--port 5001]
+                        [--sizes 8,64,96,128,163] [--max-tokens 6000]
+
+Exit code 0 only if every size at or below --required-clean-k passes both
+needles; larger sizes are reported informationally (r19's sparse DSA
+gracefully drops distant needles >=128K — expected, not a failure).
+"""
+
+import argparse
+import json
+import random
+import string
+import sys
+import time
+import urllib.error
+import urllib.request
+
+FILLER = (
+    "Paragraph %d: The logistics report for sector %d notes routine container "
+    "throughput, standard customs clearance times, and no exceptions recorded "
+    "during the audit window. "
+)
+ALPHA = "CRITICAL NOTE ALPHA: The vault code is 84291. "
+OMEGA = "CRITICAL NOTE OMEGA: The exit password is FERN-72. "
+QUESTION = (
+    "\n\nFrom the document above, answer exactly two lines:\n"
+    "Line 1: the vault code\nLine 2: the exit password"
+)
+PARAS_PER_K = 30  # ~33 tokens per salted filler paragraph
+SALT = "".join(random.choices(string.ascii_lowercase, k=10))
+
+
+def build_prompt(target_k: int) -> str:
+    """Salted per process: defeats prefix/LMCache KV reuse across runs."""
+    n = target_k * PARAS_PER_K
+    parts = []
+    for i in range(n):
+        parts.append(f"Audit run {SALT}-{i % 7}. " + FILLER % (i, i % 97))
+        if i == int(n * 0.05):
+            parts.append(ALPHA)
+        if i == int(n * 0.95):
+            parts.append(OMEGA)
+    return "".join(parts) + QUESTION
+
+
+def probe(base: str, model: str, prompt: str, max_tokens: int) -> dict:
+    body = json.dumps({
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "temperature": 0,
+        "max_tokens": max_tokens,
+    }).encode()
+    req = urllib.request.Request(
+        f"{base}/v1/chat/completions", data=body,
+        headers={"Content-Type": "application/json"})
+    t0 = time.time()
+    try:
+        with urllib.request.urlopen(req, timeout=1800) as resp:
+            j = json.load(resp)
+    except urllib.error.HTTPError as exc:
+        if exc.code == 400:
+            return {"skipped": "prompt exceeds the server context window",
+                    "wall_s": round(time.time() - t0, 1)}
+        raise
+    choice = j["choices"][0]
+    content = choice["message"].get("content") or ""
+    return {
+        "wall_s": round(time.time() - t0, 1),
+        "prompt_tokens": j["usage"]["prompt_tokens"],
+        "finish": choice["finish_reason"],
+        "alpha": "84291" in content,
+        "omega": "FERN-72" in content,
+        "content_head": content[:80],
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", required=True)
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--port", type=int, default=5001)
+    ap.add_argument("--sizes", default="8,64,96,128,163",
+                    help="approximate prompt sizes in K tokens")
+    ap.add_argument("--max-tokens", type=int, default=6000)
+    ap.add_argument("--required-clean-k", type=int, default=96,
+                    help="both needles MUST retrieve at all sizes <= this")
+    ap.add_argument("--output", default=None)
+    args = ap.parse_args()
+
+    base = f"http://{args.host}:{args.port}"
+    sizes = [int(s) for s in args.sizes.split(",")]
+    results, gate_ok = [], True
+    print(f"salt={SALT}")
+    for k in sizes:
+        r = probe(base, args.model, build_prompt(k), args.max_tokens)
+        r["target_k"] = k
+        required = k <= args.required_clean_k
+        r["required"] = required
+        if r.get("skipped"):
+            print(f"{k:>4}K  SKIP ({r['skipped']})")
+            results.append(r)
+            continue
+        ok = r["alpha"] and r["omega"]
+        if required and not ok:
+            gate_ok = False
+        print(f"{k:>4}K  prompt={r['prompt_tokens']:>7}  "
+              f"alpha={'OK' if r['alpha'] else 'FAIL'}  "
+              f"omega={'OK' if r['omega'] else 'FAIL'}  "
+              f"finish={r['finish']}  wall={r['wall_s']}s"
+              f"{'  [REQUIRED]' if required else '  [informational]'}")
+        results.append(r)
+
+    verdict = "NEEDLE_GATE_PASS" if gate_ok else "NEEDLE_GATE_FAIL"
+    print(verdict)
+    if args.output:
+        with open(args.output, "w") as f:
+            json.dump({"verdict": verdict, "salt": SALT, "results": results,
+                       "required_clean_k": args.required_clean_k}, f, indent=2)
+    return 0 if gate_ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why

Throughput cells structurally cannot catch long-context readout corruption: a model that stops attending over its KV benchmarks **faster**, not slower. We hit this with the v20 **r26** candidate on a 4x RTX PRO 6000 Workstation host at TP4/**DCP2**: every decode/prefill cell looked at parity-or-better with r19, the 512K envelope "completed" 3.4x faster than physics allows — and planted-fact probes showed the entire readout lost past ~98–128K tokens, with off-topic hallucination at 163K. (Full report shared on Discord; r22 is clean on the identical contract, bracketing the regression to the vLLM `40ee7ea → f5981f1` delta. r26's release gates ran DCP4 only, where the bug does not reproduce.)

## What

1. **`scripts/needle_gate.py`** — plants two labeled facts (5%/95% positions) in synthetic prompts of increasing size; requires exact retrieval at temperature 0 for every size ≤ `--required-clean-k` (default 96). Larger sizes are informational: sparse-DSA top-K drops *distant* facts gracefully at extreme depth, and that expected decay must not fail releases. Exit code is the verdict; JSON artifact per case.
2. **Salting** — prompts are salted per invocation. This is not cosmetic: with a persistent LMCache L2 volume, deterministic prompts, and an unchanged served-model name, KV chunks written by a broken engine are replayed into later probes of *healthy* images (2–3 s "prefills" are the tell). Two of our own bisection verdicts were corrupted this way before the salt.
3. **Runner integration** — a `NEEDLE` step in `run_case()` between CORRECTNESS and DECODE, on by default. `NEEDLE_GATE=0` skips; `NEEDLE_SIZES` / `NEEDLE_REQUIRED_CLEAN_K` tune. Sizes exceeding a case's context window are skipped, not failed (TP6/128000 cases stay green). Cost: ~2–3 min per case at the default `8,64,96`.

## Evidence it earns its runtime

On our host, this gate at defaults passes r13/r19/r22/r25-DCP4/r26-DCP4 and **fails r26-DCP2 within one probe** — i.e., it would have caught the canonical release before push. gsm8k-style accuracy cells did not move at all on the broken image.

Happy to adjust step placement, defaults, or make it opt-in instead of opt-out — maintainer's call.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable needle-gate validation for benchmark cases.
  * Added long-context retrieval checks across configurable prompt sizes.
  * Added per-size validation results with optional JSON and log output.
  * Added support for skipping probes that exceed the endpoint’s context limit.

* **Bug Fixes**
  * Validation now stops with a failure status when required prompt sizes do not meet the configured accuracy threshold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->