### PR TITLE
docs(v20): clarify online-K6 activation for direct vllm serve launches

### DIFF
--- a/models/glm5.2_v20.md
+++ b/models/glm5.2_v20.md
@@ -748,6 +748,29 @@ rename; an incomplete or invalid entry is ignored and rebuilt. The Compose
 `JIT_CACHE` volume mounts `/cache`, so reuse that same host directory to avoid
 re-encoding approximately 11.90 GB of artifacts on each cold start.
 
+**Direct `vllm serve` launches (helper bypassed):** `ONLINE_QUANT` is read
+only by the embedded helper; vLLM itself never reads it, so setting
+`ONLINE_QUANT=exl3-b6` as a plain environment variable in a Compose file
+whose entrypoint execs `vllm serve` directly is inert. Several community
+reference composes currently carry it that way. For a direct launch the
+activation contract is:
+
+```bash
+VLLM_EXL3_ONLINE_TRELLIS_BITS=6          # the actual MXFP8-vs-K6 switch (3-8)
+VLLM_EXL3_ENCODER_SOURCE=/opt/exllamav3-python/exllamav3  # REQUIRED: no baked default in vLLM
+VLLM_EXL3_ONLINE_CACHE_DIR=/cache/exl3-online              # optional (default VLLM_CACHE_ROOT/exl3_online)
+VLLM_EXL3_ONLINE_CACHE_MODE=readwrite                      # optional (already the default)
+```
+
+together with `--quantization-config` selecting `mxfp8` for `linear` (and
+optionally `shared_experts`) — that flag is the eligibility gate; the env
+var upgrades eligible tensors from MXFP8 to K6. There is no `exl3-b6`
+weight type in `--quantization-config`. Two related behaviors worth
+knowing when comparing published KLD numbers: `lm_head` is excluded from
+the online overlay in code regardless of the ignore list, and the ignore
+list filters only the `linear` spec — a `shared_experts` spec is always
+converted when present.
+
 With `MTP>0`, the helper creates a same-checkpoint MTP draft using the same MoE
 backend and probabilistic draft sampling. The target and draft share the
 virtual 66-head layout at TP6. Acceptance must be read from the server log for


### PR DESCRIPTION
Source-verified against vLLM PR #228 and the pinned launcher: `ONLINE_QUANT` is read only by `serve-glm52-v16.sh` — in composes that exec `vllm serve` directly (including current community reference composes on the 3.36/3.40 model cards), `ONLINE_QUANT=exl3-b6` as plain env is inert. This adds the direct-launch activation contract to the K6 section (`VLLM_EXL3_ONLINE_TRELLIS_BITS` is the switch; `VLLM_EXL3_ENCODER_SOURCE` is required with no baked default; cache vars optional), plus two code behaviors that matter when attributing published KLD deltas: `lm_head` is excluded from the overlay in code regardless of ignore list, and `ignore` filters only the `linear` spec while a `shared_experts` spec always converts. Companion to rtx6kpro PR #54 and vllm #236/#237 from the same campaign.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for launching the model directly with `vllm serve`.
  * Clarified required settings for quantization, encoder sources, caching, and Trellis-bit configurations.
  * Documented MXFP8 behavior, including environment-based K6 upgrades.
  * Clarified online overlay exclusions and the scope of ignore patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->