### PR TITLE
docs(v20): mixed-checkpoint r25 floor and CKV gather-bound field notes

### DIFF
--- a/models/glm5.2_v20.md
+++ b/models/glm5.2_v20.md
@@ -83,6 +83,13 @@ measured DCP prefill topology:
   state, so one cached kernel is correct for both partitions. The exact r25
   image passed TP4/DCP4/MTP3 startup, correctness, CUDA graphs, CC1/CC8
   decode, 8k/64k prefill, and source/runtime-contract gates.
+  **Compatibility floor:** checkpoints whose tier bitmaps rely on
+  runtime-dynamic partitions (the 3.40 bpw and newer mixed builds)
+  hard-require r25. Older images (r22 and earlier) fail during the
+  memory-profiling forward with a CUDA illegal-memory-access — a crash,
+  not a clean rejection — because the static mixed-K kernel indexes
+  per-layer tier tables the checkpoint no longer matches. Field report:
+  4x RTX PRO 6000 Workstation, r22 + willfalco 3.40 bpw, 2026-08-04.
 - r26 corrects the automatic TP4/DCP4 prefill policy. Because TP4/DCP4 has
   only one query partition, exact owner exchange adds transport without
   removing duplicate work. Auto mode now uses query split, full CKV gather,
@@ -856,6 +863,11 @@ The 16,384 rows are deliberately forced negative controls, not the historical
 v20 baseline. Correctly configured TP8/DCP4 had already measured about
 5.6-5.85k tok/s before r5; the explicit 140k helper default prevents an old
 external override from silently losing that established fast path.
+Field note (2026-08-04): several community model-card composes circulate
+`VLLM_B12X_MLA_CKV_GATHER_MAX_TOKENS=16384` as if it were a tuning value;
+on a 4x RTX PRO 6000 host that setting halved 64k pure prefill
+(1,478 vs 2,895 tok/s) against the documented 140k default on the same
+boot. Audit external composes for this override before benchmarking.
 
 At prefetch depth 0 and one execution lane, the 140k FP8-KV workspace is
 approximately 131.4 MiB/GPU for DCP2, 109.5 MiB for DCP4, and 98.7 MiB for


### PR DESCRIPTION
Two field-verified additions from the 3.40bpw campaign on our quad RTX PRO 6000 host (same campaign as #54/#56 and the tuning results posted to Discord):

1. **r25 compatibility floor for runtime-dynamic mixed checkpoints.** The 3.40bpw (and any tier bitmap relying on #117 runtime-dynamic partitions) crashes r22-and-older with a CUDA illegal memory access mid-profiling — a hard fault, not a clean rejection. One sentence in the r25 release note saves the next person a confusing corpse.

2. **CKV gather-bound anti-pattern warning.** The wiki already documents 16384 as a forced negative control — but several community model-card composes ship `VLLM_B12X_MLA_CKV_GATHER_MAX_TOKENS=16384` as if it were tuning. Measured on the same boot: 64k pure prefill 1,478 vs 2,895 tok/s against the 140k default. A field note pointing at the circulating override.

Both additions are pure prose; no behavioral claims beyond our measurements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added compatibility guidance for runtime-dynamic mixed EXL3 partitions, including the r25 requirement.
  * Documented a potential crash when older images perform memory profiling.
  * Added a performance note about reduced 64k prefill throughput when using a 16,384-token CKV gather limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->