### PR TITLE
II: Document the qualified Kimi-K3 TP16/DCP16 runtime

### DIFF
--- a/models/kimi-k3/README.md
+++ b/models/kimi-k3/README.md
@@ -1,217 +1,213 @@
-# Kimi-K3 TP16 Runtime on RTX PRO 6000 Blackwell
+# Kimi-K3 TP16/DCP16 Runtime on RTX PRO 6000 Blackwell
 
-This page specifies the qualified vLLM runtime for `moonshotai/Kimi-K3` on 16
-RTX PRO 6000 Blackwell Server Edition GPUs. The target checkpoint retains its
-source MXFP4 expert weights. Three server profiles are packaged in one image:
-target-only decode, BF16 DSpark K7, and online-MXFP8 DFlash K7.
+Status: **qualified**.
+
+This page specifies the containerized vLLM runtime for `moonshotai/Kimi-K3`
+on 16 NVIDIA RTX PRO 6000 Blackwell Server Edition GPUs. The target checkpoint
+retains its MXFP4 expert weights and uses FP8 KV cache. One image provides
+target-only decode, seven-token DSpark speculative decode, and seven-token
+DFlash speculative decode.
 
 ## Qualified Artifact
 
 | Item | Durable identifier |
 |---|---|
-| Docker image | `voipmonitor/vllm:kimi-k3-hh-vllm138eccd-b12x7617005-cu132-20260811-r2` |
-| Registry digest | `sha256:7ca3d4ffc6d5812984b3164e1ec821104bfa5ae85a5467aea9e86e7462943092` |
-| Local image ID used for qualification | `sha256:4d8f652e2c1f268a9b14f290a72bba745825f4ea1ecbeeec45c49dbe794e1626` |
-| Docker recipe | [`build/kimi-k3-hh-pr-stack-20260811`](https://github.com/local-inference-lab/blackwell-llm-docker/tree/build/kimi-k3-hh-pr-stack-20260811) at `d97246b15744fbda49cc0405b74111156e140293` |
+| Docker image | `voipmonitor/vllm:kimi-k3-infernal-vllmde04f08-b12x2e6092a-cu133-torch213-20260812-r1` |
+| Registry digest | `sha256:974edc237f27a4eaa83a53ce4927dd176a5ad8ce4fbb8d3d689fce82348531a5` |
+| Local image ID used for qualification | `sha256:4be1d706e29cc5d53fc2891378ba185538d5a35e69793062a8f973f1886217f0` |
+| Docker recipe | [`build/kimi-k3-ii-cu133-torch213-20260811@697f50f`](https://github.com/local-inference-lab/blackwell-llm-docker/tree/697f50ff644f2c418645c64a50828dccce597d38) |
+| vLLM integration | [`integration/kimi-k3-ii-cu133-torch213-20260811@881ac39`](https://github.com/local-inference-lab/vllm/tree/881ac39a4fb6c5bbfa14f3944db560e0a27f3ffe) |
 | Target checkpoint | `moonshotai/Kimi-K3@2496450e92e425c886db095102a52a6682ca3970` |
 | Runtime topology | TP16, DCP16, A2A DCP communication |
 | Target KV dtype | FP8 |
-| Weight loader | InstantTensor |
-| Status | Qualified |
+| Weight loader | InstantTensor 0.1.9 |
 
-The image is based on the immutable CUDA runtime
-`voipmonitor/vllm@sha256:820181fbbc975cd5291c411cda9771d58fecee1636d916f508f47230df20592b`.
-It rebuilds all vLLM native extensions from the composed Heraldic Harbinger
-source instead of reusing the base image extensions.
+The image uses CUDA 13.3, PyTorch 2.13.0, NCCL 2.31.2, FlashInfer
+0.6.15.post1, and B12X for target MLA decode.
 
 ## Source Composition
 
-The Docker recipe applies only the changes required by the Kimi-K3 profiles.
+The image composes the following immutable source trees:
 
-| Repository | Clean base | Applied PR heads | Resulting Git tree |
+| Repository | Base | Applied changes | Resulting Git tree |
 |---|---|---|---|
-| `local-inference-lab/vllm` | `dev/heraldic-harbinger@6389c45f4d172d5414526e0969e3c689096f1959` | [#242](https://github.com/local-inference-lab/vllm/pull/242) `fbd738571739e5e629da44ed40e486a8e6cdc1b8`; [#278](https://github.com/local-inference-lab/vllm/pull/278) `23d51b1953814eca0090c930c5e6cd99bc396253` | `138eccd127bb6e2b5c52940203d36b951a3c6284` |
-| `local-inference-lab/b12x` | `master@ce7f62275b12ceaeee71e603fb2419bb556e166a` | [#124](https://github.com/local-inference-lab/b12x/pull/124) `5b6a53f7e83413d717c6b797eece9ce079f86954`; [#138](https://github.com/local-inference-lab/b12x/pull/138) `8596afcf10a3c48f2329ee34ce6e310ceeb6d110`; [#139](https://github.com/local-inference-lab/b12x/pull/139) `a5089aa3c6aa8cbe40dbdaf520a6c8bddf1d50e8` | `76170059b95c2189966476ddd6eb872a886882c4` |
+| `local-inference-lab/vllm` | `dev/infernal-invocation@c8d04a543e0e8b0896e60b8b11bec0bb2d780860` | Kimi-K3 TP16/DCP16 serving commit `881ac39a4fb6c5bbfa14f3944db560e0a27f3ffe` | `de04f08beb6ff0ef05189c31927f3a3320b1a6f1` |
+| `local-inference-lab/b12x` | `master@184d7d52ad630841d0c6caf962f8b9d36f38992a` | PR [#124](https://github.com/local-inference-lab/b12x/pull/124), [#138](https://github.com/local-inference-lab/b12x/pull/138), and [#139](https://github.com/local-inference-lab/b12x/pull/139) | `2e6092a74d2449b8f8fa65d0c980533002db76cb` |
 
-B12X PR #141 is an integration branch containing the same runtime changes as
-#124, #138, and #139. It is not applied on top of those PRs because doing so
-would duplicate the integration content.
+The Docker recipe stores integration locks and verified patches under
+`patches/releases/kimi-k3-infernal-invocation-runtime-r1/` and
+`patches/releases/kimi-k3-hh-runtime-r1/`. The locks pin base commits, applied
+PR heads, patch SHA-256 values, and resulting Git trees.
 
-The archived integration locks and patches are under
-`patches/releases/kimi-k3-hh-runtime-r1/` in the Docker recipe. Each lock pins
-the clean base, PR heads, integration patch SHA-256, and resulting Git tree.
-
-## Checkpoints
+## Checkpoints and Runtime Weight Formats
 
 Populate the Hugging Face cache mounted at `/root/.cache/huggingface` with the
-target and the draft required by the selected profile:
+target checkpoint and the draft checkpoint required by the selected profile:
 
 | Role | Checkpoint | Runtime format |
 |---|---|---|
-| Target | `moonshotai/Kimi-K3@2496450e92e425c886db095102a52a6682ca3970` | Source MXFP4 experts; InstantTensor load |
-| DSpark draft | `Inferact/Kimi-K3-DSpark@cf6b8244620e7ea4b0651d214f28e89eac75bed6` | BF16, TP-sharded at runtime |
+| Target | `moonshotai/Kimi-K3@2496450e92e425c886db095102a52a6682ca3970` | Checkpoint MXFP4 experts; InstantTensor load |
+| DSpark draft | `Inferact/Kimi-K3-DSpark@cf6b8244620e7ea4b0651d214f28e89eac75bed6` | Online MXFP8 linears; `fused_qkv_a_proj` remains BF16 |
 | DFlash draft | `modal-labs/Kimi-K3-DFlash@c192d15a43407bf758b5ae0880d5c72052fef1de` | Online MXFP8 linears; `qkv_proj` remains BF16 |
 
-The DSpark and DFlash profiles quantize the target KDA input projections to
-online MXFP8. The target-only profile does not apply that projection
-quantization. None of the three profiles uses the discontinued NF3 checkpoint.
+The DSpark and DFlash launchers convert selected BF16 target KDA projections
+to MXFP8 as each source tensor is loaded. They do not retain all BF16 KDA
+projections simultaneously and do not move KDA projection repacking to a CPU
+fallback. During conversion, GPU memory briefly contains the BF16 source,
+MXFP8 output and scales, repack workspace, and InstantTensor staging buffers.
 
-## Cache Isolation
+The DSpark cold-load qualification reached less than 21 MiB free memory per
+GPU and emitted recoverable expandable-segment mapping warnings. Loading
+completed, and the steady server passed decode qualification. One 4.45 GiB
+DSpark draft tensor exceeds the 2.35 GiB InstantTensor ring and therefore uses
+CPU safetensors; that tensor is not a target KDA projection.
 
-Use a separate host directory for each `/cache/jit` mount. The vLLM, Triton,
-CuTe DSL, and B12X caches use source fingerprint
-`vllm138eccd127-b12x76170059b9`. Profile-level isolation prevents target-only,
-DSpark, and DFlash CUDA-graph state from being mixed.
+## Cache Isolation and Port Selection
+
+Each runtime profile requires an independent writable `/cache/jit` directory.
+The profiles use different CUDA graph shapes and generated kernels; sharing a
+JIT directory between profiles is unsupported.
 
 ```bash
-mkdir -p /mnt/luke/kimi-k3-cache/hh-runtime-nospec
-mkdir -p /mnt/luke/kimi-k3-cache/hh-runtime-dspark
-mkdir -p /mnt/luke/kimi-k3-cache/hh-runtime-dflash
+mkdir -p /mnt/luke/kimi-k3-cache/infernal-release-20260812/nospec
+mkdir -p /mnt/luke/kimi-k3-cache/infernal-release-20260812/dspark
+mkdir -p /mnt/luke/kimi-k3-cache/infernal-release-20260812/dflash
 ```
 
-The launch commands below use host networking. On the qualified host, a
-systemd proxy exposes `127.0.0.1:8001` as host port `8000`, so `PORT=8001` is
-required inside the container. On a host without that proxy, set `PORT=8000`
-and call port 8000 directly.
+The launch commands use host networking and set the vLLM server to port 8001.
+The qualified host has a local proxy from host port 8000 to port 8001. On a
+host where port 8000 is directly available, replace `-e PORT=8001` with
+`-e PORT=8000`.
 
 ## Start Target-Only Decode
 
 ```bash
 docker run -d \
-  --name kimi-k3-hh-nospec \
+  --name kimi-k3-infernal-nospec \
   --gpus all \
   --network host \
   --ipc=host \
-  --shm-size=16g \
+  --shm-size=32g \
+  --ulimit memlock=-1 \
+  --ulimit stack=67108864 \
+  --ulimit nofile=1048576:1048576 \
   -e PORT=8001 \
-  -v /root/.cache/huggingface:/root/.cache/huggingface \
-  -v /mnt/luke/kimi-k3-cache/hh-runtime-nospec:/cache/jit \
+  -v /root/.cache/huggingface:/root/.cache/huggingface:ro \
+  -v /mnt/luke/kimi-k3-cache/infernal-release-20260812/nospec:/cache/jit \
   --entrypoint /usr/local/bin/serve-kimi-k3-nospec \
-  voipmonitor/vllm:kimi-k3-hh-vllm138eccd-b12x7617005-cu132-20260811-r2
+  voipmonitor/vllm:kimi-k3-infernal-vllmde04f08-b12x2e6092a-cu133-torch213-20260812-r1
 ```
 
-The served model name is `Kimi-K3-MXFP4-HH-DCP16-1M-NoDSpark`.
+The served model name is `Kimi-K3-MXFP4-DCP16-1M`.
 
 ## Start DSpark
 
 The image defaults to the DSpark launcher. The explicit entrypoint below makes
-the selected profile visible in container metadata. The scheduler variables
-are part of the qualified single-request K7 configuration.
+the selected profile visible in container metadata.
 
 ```bash
 docker run -d \
-  --name kimi-k3-hh-dspark \
+  --name kimi-k3-infernal-dspark \
   --gpus all \
   --network host \
   --ipc=host \
-  --shm-size=16g \
+  --shm-size=32g \
+  --ulimit memlock=-1 \
+  --ulimit stack=67108864 \
+  --ulimit nofile=1048576:1048576 \
   -e PORT=8001 \
-  -e 'DSPARK_BATCH_SIZE_SPECULATIVE_SCHEDULE=[[1,1,7]]' \
-  -e DSPARK_CAPACITY_ACTIVATION_BATCH_SIZE=2 \
-  -e VLLM_DSPARK_CAPACITY_ACTIVATION_BATCH_SIZE=2 \
-  -e DSPARK_SPS_CURVE=auto \
-  -e VLLM_DSPARK_DYNAMIC_DRAFT_DEPTH=1 \
-  -v /root/.cache/huggingface:/root/.cache/huggingface \
-  -v /mnt/luke/kimi-k3-cache/hh-runtime-dspark:/cache/jit \
+  -v /root/.cache/huggingface:/root/.cache/huggingface:ro \
+  -v /mnt/luke/kimi-k3-cache/infernal-release-20260812/dspark:/cache/jit \
   --entrypoint /usr/local/bin/serve-kimi-k3-dspark \
-  voipmonitor/vllm:kimi-k3-hh-vllm138eccd-b12x7617005-cu132-20260811-r2
+  voipmonitor/vllm:kimi-k3-infernal-vllmde04f08-b12x2e6092a-cu133-torch213-20260812-r1
 ```
 
-The served model name is
-`Kimi-K3-MXFP4-HH-DSpark7-BF16-DCP16-1M-KDA-MXFP8-P4096`.
+The served model name is `Kimi-K3-MXFP4-DSpark7-DCP16-1M`.
 
 ## Start DFlash
 
 ```bash
 docker run -d \
-  --name kimi-k3-hh-dflash \
+  --name kimi-k3-infernal-dflash \
   --gpus all \
   --network host \
   --ipc=host \
-  --shm-size=16g \
+  --shm-size=32g \
+  --ulimit memlock=-1 \
+  --ulimit stack=67108864 \
+  --ulimit nofile=1048576:1048576 \
   -e PORT=8001 \
-  -v /root/.cache/huggingface:/root/.cache/huggingface \
-  -v /mnt/luke/kimi-k3-cache/hh-runtime-dflash:/cache/jit \
+  -v /root/.cache/huggingface:/root/.cache/huggingface:ro \
+  -v /mnt/luke/kimi-k3-cache/infernal-release-20260812/dflash:/cache/jit \
   --entrypoint /usr/local/bin/serve-kimi-k3-dflash \
-  voipmonitor/vllm:kimi-k3-hh-vllm138eccd-b12x7617005-cu132-20260811-r2
+  voipmonitor/vllm:kimi-k3-infernal-vllmde04f08-b12x2e6092a-cu133-torch213-20260812-r1
 ```
 
-The served model name is `Kimi-K3-MXFP4-HH-DFlash-DCP16-1M`.
+The served model name is `Kimi-K3-MXFP4-DFlash-DCP16-1M`.
 
 ## Readiness and Smoke Test
 
 Wait for `Application startup complete` before sending a request:
 
 ```bash
-docker logs -f kimi-k3-hh-dspark
-curl -fsS http://127.0.0.1:8000/v1/models | python3 -m json.tool
+docker logs -f kimi-k3-infernal-dspark
+curl -fsS http://127.0.0.1:8000/v1/models | jq .
 curl -fsS http://127.0.0.1:8000/v1/completions \
   -H 'Content-Type: application/json' \
   -d '{
-    "model": "Kimi-K3-MXFP4-HH-DSpark7-BF16-DCP16-1M-KDA-MXFP8-P4096",
+    "model": "Kimi-K3-MXFP4-DSpark7-DCP16-1M",
     "prompt": "Write one sentence about speculative decoding.",
     "max_tokens": 32,
     "temperature": 0
   }'
 ```
 
-## Qualified Capacity and Throughput
+## Qualified Capacity and Decode Throughput
 
 Measurements used 16 RTX PRO 6000 Blackwell Server Edition GPUs, TP16/DCP16,
-one active request, a 256-token prompt, and up to 1,024 generated tokens. The
+one active request, a 256-token prompt, and 1,024 generated tokens. The
 target-only protocol constrained generation to token ID 13 so model output did
-not affect per-token timing. Speculative measurements used natural greedy
-generation and report medians across six post-warmup requests.
+not affect per-token timing. Speculative measurements used greedy sampling.
 
-| Profile | Reported target KV tokens | Decode tok/s median | Target cycles/s median | Draft acceptance median |
-|---|---:|---:|---:|---:|
-| Target-only | 1,460,937 | 56.30 | n/a | n/a |
-| DSpark K7 | 1,057,049 | 107.24 | 30.22 | 0.364 |
-| DFlash K7 | 1,039,043 | 93.67 | 29.57 | 0.310 |
+| Profile | Reported target KV tokens | Decode tok/s median | Target cycles/s median | Draft acceptance median | Measured requests |
+|---|---:|---:|---:|---:|---:|
+| Target-only | 1,460,937 | 56.05 | n/a | n/a | 8 |
+| DSpark K7 | 1,057,049 | 118.92 | 30.90 | 0.409 | 8 |
+| DFlash K7 | 1,048,576 | 89.35 | 30.34 | 0.277 | 6 |
 
-The DSpark target KV allocation exceeds 1,048,576 tokens by 8,473 tokens. The
-DFlash allocation is 9,533 tokens, or 0.91%, below that exact length; vLLM
-reports 0.99 maximum concurrency for a 1,048,576-token request.
-
-Three independent Sieve coding requests produced these generation-only rates:
-
-| Profile | Runs (tok/s) | Median (tok/s) | CJK characters |
-|---|---|---:|---:|
-| DSpark K7 | 123.49, 104.01, 137.83 | 123.49 | 0 |
-| DFlash K7 | 129.04, 161.33, 159.21 | 159.21 | 0 |
-
-Coding throughput is acceptance- and output-dependent; use target cycles per
-second to compare target runtime overhead independently of generated text.
-
-InstantTensor loaded target-only weights in 163.68 seconds and completed the
-target-only model load in 186.86 seconds. The complete DSpark and DFlash model
-loads took approximately 203.0 and 196.34 seconds respectively on a warm host
-filesystem cache.
+The DSpark model emitted a median 3.865 tokens per target cycle. The DFlash
+model emitted a median 2.940 tokens per target cycle. Target weight loading
+took 161.42 seconds for target-only, 165.29 seconds for DSpark, and 164.01
+seconds for DFlash. Complete model loading took 185.96, 186.99, and 190.56
+seconds, respectively.
 
 ## Build the Image
+
+Commit `697f50ff644f2c418645c64a50828dccce597d38` is the exact Docker recipe
+embedded in the qualified image:
 
 ```bash
 git clone https://github.com/local-inference-lab/blackwell-llm-docker.git
 cd blackwell-llm-docker
-git checkout build/kimi-k3-hh-pr-stack-20260811
-./build-kimi-k3-hh-runtime.sh
+git checkout 697f50ff644f2c418645c64a50828dccce597d38
+./build-kimi-k3-infernal-invocation-cu133-torch213.sh
 ```
 
-The builder verifies both integration patch hashes and resulting Git trees,
-then verifies the corresponding image labels. To publish the resulting tag in
-the same operation, set `PUSH_IMAGE=1`.
+Set `PUSH_IMAGE=1` to push the resulting image after build and smoke checks.
+The builder verifies source patch hashes, resulting Git trees, image labels,
+the Python runtime, native extension imports, and a 16-rank NCCL collective.
 
 ## Evidence
 
-The machine-readable image receipt is
-[`validation/kimi-k3-hh-runtime-20260811.json`](https://github.com/local-inference-lab/blackwell-llm-docker/blob/build/kimi-k3-hh-pr-stack-20260811/validation/kimi-k3-hh-runtime-20260811.json).
-Full local server logs, container inspections, request summaries, and generated
-outputs are stored under:
+The machine-readable qualification receipt is
+[`validation/kimi-k3-infernal-invocation-runtime-20260812.json`](https://github.com/local-inference-lab/blackwell-llm-docker/blob/2229e9e331eaa4f6a809aabb20f76ca384016cb2/validation/kimi-k3-infernal-invocation-runtime-20260812.json).
+Server logs, container inspections, and normalized benchmark summaries from
+the qualified host are stored under:
 
 ```text
-/mnt/luke/kimi-k3-runs/hh-release-20260811
+/mnt/luke/kimi-k3-runs/infernal-release-20260812
 ```
 
-The raw local evidence is machine-specific and is not required to rebuild the
-image; the committed lock files and validation receipt carry the durable source
-and result identities.
+The host-local evidence is not required to rebuild the image. The integration
+locks and qualification receipt contain the durable source and result
+identities.

--- a/models/kimi-k3/README.md
+++ b/models/kimi-k3/README.md
@@ -20,6 +20,7 @@ seven-token DFlash speculative decode.
 | Base image ID used for qualification | `sha256:651f0d37bc3da8469a2b9257bcff060f5509cc0d97c18f2bf340a6e5ce68d532` |
 | Base image recipe | [`3775a0b`](https://github.com/local-inference-lab/blackwell-llm-docker/tree/3775a0b6bcf30350c329f69ab55df7f3ecc8764b) |
 | vLLM integration | [`integration/kimi-k3-ii-cu133-torch213-20260811@881ac39`](https://github.com/local-inference-lab/vllm/tree/881ac39a4fb6c5bbfa14f3944db560e0a27f3ffe) |
+| vLLM review | [`local-inference-lab/vllm#284`](https://github.com/local-inference-lab/vllm/pull/284) |
 | Target checkpoint | `moonshotai/Kimi-K3@2496450e92e425c886db095102a52a6682ca3970` |
 | Runtime topology | TP16, DCP16, A2A DCP communication |
 | Target KV dtype | FP8 |

--- a/models/kimi-k3/README.md
+++ b/models/kimi-k3/README.md
@@ -58,10 +58,10 @@ quantization. None of the three profiles uses the discontinued NF3 checkpoint.
 
 ## Cache Isolation
 
-Use a separate host directory for each `/cache/jit` mount. The image namespaces
-generated artifacts with source fingerprint
-`vllm138eccd127-b12x76170059b9`, while profile-level isolation prevents
-target-only, DSpark, and DFlash CUDA-graph state from being mixed.
+Use a separate host directory for each `/cache/jit` mount. The vLLM, Triton,
+CuTe DSL, and B12X caches use source fingerprint
+`vllm138eccd127-b12x76170059b9`. Profile-level isolation prevents target-only,
+DSpark, and DFlash CUDA-graph state from being mixed.
 
 ```bash
 mkdir -p /mnt/luke/kimi-k3-cache/hh-runtime-nospec

--- a/models/kimi-k3/README.md
+++ b/models/kimi-k3/README.md
@@ -16,6 +16,9 @@ seven-token DFlash speculative decode.
 | Registry digest | `sha256:974edc237f27a4eaa83a53ce4927dd176a5ad8ce4fbb8d3d689fce82348531a5` |
 | Local image ID used for qualification | `sha256:4be1d706e29cc5d53fc2891378ba185538d5a35e69793062a8f973f1886217f0` |
 | Docker recipe | [`build/kimi-k3-ii-cu133-torch213-20260811@697f50f`](https://github.com/local-inference-lab/blackwell-llm-docker/tree/697f50ff644f2c418645c64a50828dccce597d38) |
+| Base image | `voipmonitor/vllm:kimi-k3-cu133-torch213-nccl2312-20260811-r2` |
+| Base image ID used for qualification | `sha256:651f0d37bc3da8469a2b9257bcff060f5509cc0d97c18f2bf340a6e5ce68d532` |
+| Base image recipe | [`3775a0b`](https://github.com/local-inference-lab/blackwell-llm-docker/tree/3775a0b6bcf30350c329f69ab55df7f3ecc8764b) |
 | vLLM integration | [`integration/kimi-k3-ii-cu133-torch213-20260811@881ac39`](https://github.com/local-inference-lab/vllm/tree/881ac39a4fb6c5bbfa14f3944db560e0a27f3ffe) |
 | Target checkpoint | `moonshotai/Kimi-K3@2496450e92e425c886db095102a52a6682ca3970` |
 | Runtime topology | TP16, DCP16, A2A DCP communication |
@@ -183,24 +186,53 @@ seconds, respectively.
 
 ## Build the Image
 
-Commit `697f50ff644f2c418645c64a50828dccce597d38` is the exact Docker recipe
-embedded in the qualified image:
+Pull the byte-identical qualified runtime by digest:
+
+```bash
+docker pull \
+  voipmonitor/vllm@sha256:974edc237f27a4eaa83a53ce4927dd176a5ad8ce4fbb8d3d689fce82348531a5
+```
+
+The following commands rebuild the pinned base and runtime source
+compositions. Native compiler metadata can make the rebuilt image digest
+differ even when all pinned source trees and runtime interfaces match.
 
 ```bash
 git clone https://github.com/local-inference-lab/blackwell-llm-docker.git
 cd blackwell-llm-docker
+
+git checkout 3775a0b6bcf30350c329f69ab55df7f3ecc8764b
+IMAGE=voipmonitor/vllm:kimi-k3-cu133-torch213-nccl2312-20260811-r2 \
+RELEASE_DATE=20260811 \
+REVISION=r2 \
+./build-kimi-k3-cu133-torch213-base.sh
+
 git checkout 697f50ff644f2c418645c64a50828dccce597d38
+BASE_IMAGE=voipmonitor/vllm:kimi-k3-cu133-torch213-nccl2312-20260811-r2 \
+IMAGE=voipmonitor/vllm:kimi-k3-infernal-vllmde04f08-b12x2e6092a-cu133-torch213-20260812-r1 \
+RELEASE_DATE=20260812 \
+REVISION=r1 \
 ./build-kimi-k3-infernal-invocation-cu133-torch213.sh
 ```
 
-Set `PUSH_IMAGE=1` to push the resulting image after build and smoke checks.
-The builder verifies source patch hashes, resulting Git trees, image labels,
-the Python runtime, native extension imports, and a 16-rank NCCL collective.
+The base builder starts from
+`nvcr.io/nvidia/pytorch:26.07-py3@sha256:2140e699b3beaf7f96a0081fd9c9406bc3832b435cdb60dfa2d261f7d2f34a1c`.
+It builds PyTorch 2.13.0 from
+`cf30153c4c131c8164ee7798e5022d810682e2cb`, Torchvision 0.28.0 from
+`8fb87713a24951e639c494b0f2a8a81b5f8e33a6`, patched NCCL 2.31.2 from
+`fb6f40999a2a9e63104d4ae4a84118bce61528f8`, and XGrammar 0.2.5 from
+`2ea71da4ccb997a06928c9fb69b99f330da56697`.
+
+The base builder runs CUDA, Torchvision, and 16-rank NCCL smoke tests. The
+runtime builder verifies the vLLM and B12X integration patch hashes and Git
+trees, builds the native extensions, verifies installed package versions and
+imports, and repeats the 16-rank NCCL smoke test. Set `PUSH_IMAGE=1` on either
+builder to publish its output after validation.
 
 ## Evidence
 
 The machine-readable qualification receipt is
-[`validation/kimi-k3-infernal-invocation-runtime-20260812.json`](https://github.com/local-inference-lab/blackwell-llm-docker/blob/f05633234d99a300f259ec427052d54b0a55c17e/validation/kimi-k3-infernal-invocation-runtime-20260812.json).
+[`validation/kimi-k3-infernal-invocation-runtime-20260812.json`](https://github.com/local-inference-lab/blackwell-llm-docker/blob/7ae7b4ef40ed0b7c3c4cd6551ecb3dfc81578f3e/validation/kimi-k3-infernal-invocation-runtime-20260812.json).
 Server logs, container inspections, and normalized benchmark summaries from
 the qualified host are stored under:
 

--- a/models/kimi-k3/README.md
+++ b/models/kimi-k3/README.md
@@ -1,0 +1,217 @@
+# Kimi-K3 TP16 Runtime on RTX PRO 6000 Blackwell
+
+This page specifies the qualified vLLM runtime for `moonshotai/Kimi-K3` on 16
+RTX PRO 6000 Blackwell Server Edition GPUs. The target checkpoint retains its
+source MXFP4 expert weights. Three server profiles are packaged in one image:
+target-only decode, BF16 DSpark K7, and online-MXFP8 DFlash K7.
+
+## Qualified Artifact
+
+| Item | Durable identifier |
+|---|---|
+| Docker image | `voipmonitor/vllm:kimi-k3-hh-vllm138eccd-b12x7617005-cu132-20260811-r2` |
+| Registry digest | `sha256:7ca3d4ffc6d5812984b3164e1ec821104bfa5ae85a5467aea9e86e7462943092` |
+| Local image ID used for qualification | `sha256:4d8f652e2c1f268a9b14f290a72bba745825f4ea1ecbeeec45c49dbe794e1626` |
+| Docker recipe | [`build/kimi-k3-hh-pr-stack-20260811`](https://github.com/local-inference-lab/blackwell-llm-docker/tree/build/kimi-k3-hh-pr-stack-20260811) at `d97246b15744fbda49cc0405b74111156e140293` |
+| Target checkpoint | `moonshotai/Kimi-K3@2496450e92e425c886db095102a52a6682ca3970` |
+| Runtime topology | TP16, DCP16, A2A DCP communication |
+| Target KV dtype | FP8 |
+| Weight loader | InstantTensor |
+| Status | Qualified |
+
+The image is based on the immutable CUDA runtime
+`voipmonitor/vllm@sha256:820181fbbc975cd5291c411cda9771d58fecee1636d916f508f47230df20592b`.
+It rebuilds all vLLM native extensions from the composed Heraldic Harbinger
+source instead of reusing the base image extensions.
+
+## Source Composition
+
+The Docker recipe applies only the changes required by the Kimi-K3 profiles.
+
+| Repository | Clean base | Applied PR heads | Resulting Git tree |
+|---|---|---|---|
+| `local-inference-lab/vllm` | `dev/heraldic-harbinger@6389c45f4d172d5414526e0969e3c689096f1959` | [#242](https://github.com/local-inference-lab/vllm/pull/242) `fbd738571739e5e629da44ed40e486a8e6cdc1b8`; [#278](https://github.com/local-inference-lab/vllm/pull/278) `23d51b1953814eca0090c930c5e6cd99bc396253` | `138eccd127bb6e2b5c52940203d36b951a3c6284` |
+| `local-inference-lab/b12x` | `master@ce7f62275b12ceaeee71e603fb2419bb556e166a` | [#124](https://github.com/local-inference-lab/b12x/pull/124) `5b6a53f7e83413d717c6b797eece9ce079f86954`; [#138](https://github.com/local-inference-lab/b12x/pull/138) `8596afcf10a3c48f2329ee34ce6e310ceeb6d110`; [#139](https://github.com/local-inference-lab/b12x/pull/139) `a5089aa3c6aa8cbe40dbdaf520a6c8bddf1d50e8` | `76170059b95c2189966476ddd6eb872a886882c4` |
+
+B12X PR #141 is an integration branch containing the same runtime changes as
+#124, #138, and #139. It is not applied on top of those PRs because doing so
+would duplicate the integration content.
+
+The archived integration locks and patches are under
+`patches/releases/kimi-k3-hh-runtime-r1/` in the Docker recipe. Each lock pins
+the clean base, PR heads, integration patch SHA-256, and resulting Git tree.
+
+## Checkpoints
+
+Populate the Hugging Face cache mounted at `/root/.cache/huggingface` with the
+target and the draft required by the selected profile:
+
+| Role | Checkpoint | Runtime format |
+|---|---|---|
+| Target | `moonshotai/Kimi-K3@2496450e92e425c886db095102a52a6682ca3970` | Source MXFP4 experts; InstantTensor load |
+| DSpark draft | `Inferact/Kimi-K3-DSpark@cf6b8244620e7ea4b0651d214f28e89eac75bed6` | BF16, TP-sharded at runtime |
+| DFlash draft | `modal-labs/Kimi-K3-DFlash@c192d15a43407bf758b5ae0880d5c72052fef1de` | Online MXFP8 linears; `qkv_proj` remains BF16 |
+
+The DSpark and DFlash profiles quantize the target KDA input projections to
+online MXFP8. The target-only profile does not apply that projection
+quantization. None of the three profiles uses the discontinued NF3 checkpoint.
+
+## Cache Isolation
+
+Use a separate host directory for each `/cache/jit` mount. The image namespaces
+generated artifacts with source fingerprint
+`vllm138eccd127-b12x76170059b9`, while profile-level isolation prevents
+target-only, DSpark, and DFlash CUDA-graph state from being mixed.
+
+```bash
+mkdir -p /mnt/luke/kimi-k3-cache/hh-runtime-nospec
+mkdir -p /mnt/luke/kimi-k3-cache/hh-runtime-dspark
+mkdir -p /mnt/luke/kimi-k3-cache/hh-runtime-dflash
+```
+
+The launch commands below use host networking. On the qualified host, a
+systemd proxy exposes `127.0.0.1:8001` as host port `8000`, so `PORT=8001` is
+required inside the container. On a host without that proxy, set `PORT=8000`
+and call port 8000 directly.
+
+## Start Target-Only Decode
+
+```bash
+docker run -d \
+  --name kimi-k3-hh-nospec \
+  --gpus all \
+  --network host \
+  --ipc=host \
+  --shm-size=16g \
+  -e PORT=8001 \
+  -v /root/.cache/huggingface:/root/.cache/huggingface \
+  -v /mnt/luke/kimi-k3-cache/hh-runtime-nospec:/cache/jit \
+  --entrypoint /usr/local/bin/serve-kimi-k3-nospec \
+  voipmonitor/vllm:kimi-k3-hh-vllm138eccd-b12x7617005-cu132-20260811-r2
+```
+
+The served model name is `Kimi-K3-MXFP4-HH-DCP16-1M-NoDSpark`.
+
+## Start DSpark
+
+The image defaults to the DSpark launcher. The explicit entrypoint below makes
+the selected profile visible in container metadata. The scheduler variables
+are part of the qualified single-request K7 configuration.
+
+```bash
+docker run -d \
+  --name kimi-k3-hh-dspark \
+  --gpus all \
+  --network host \
+  --ipc=host \
+  --shm-size=16g \
+  -e PORT=8001 \
+  -e 'DSPARK_BATCH_SIZE_SPECULATIVE_SCHEDULE=[[1,1,7]]' \
+  -e DSPARK_CAPACITY_ACTIVATION_BATCH_SIZE=2 \
+  -e VLLM_DSPARK_CAPACITY_ACTIVATION_BATCH_SIZE=2 \
+  -e DSPARK_SPS_CURVE=auto \
+  -e VLLM_DSPARK_DYNAMIC_DRAFT_DEPTH=1 \
+  -v /root/.cache/huggingface:/root/.cache/huggingface \
+  -v /mnt/luke/kimi-k3-cache/hh-runtime-dspark:/cache/jit \
+  --entrypoint /usr/local/bin/serve-kimi-k3-dspark \
+  voipmonitor/vllm:kimi-k3-hh-vllm138eccd-b12x7617005-cu132-20260811-r2
+```
+
+The served model name is
+`Kimi-K3-MXFP4-HH-DSpark7-BF16-DCP16-1M-KDA-MXFP8-P4096`.
+
+## Start DFlash
+
+```bash
+docker run -d \
+  --name kimi-k3-hh-dflash \
+  --gpus all \
+  --network host \
+  --ipc=host \
+  --shm-size=16g \
+  -e PORT=8001 \
+  -v /root/.cache/huggingface:/root/.cache/huggingface \
+  -v /mnt/luke/kimi-k3-cache/hh-runtime-dflash:/cache/jit \
+  --entrypoint /usr/local/bin/serve-kimi-k3-dflash \
+  voipmonitor/vllm:kimi-k3-hh-vllm138eccd-b12x7617005-cu132-20260811-r2
+```
+
+The served model name is `Kimi-K3-MXFP4-HH-DFlash-DCP16-1M`.
+
+## Readiness and Smoke Test
+
+Wait for `Application startup complete` before sending a request:
+
+```bash
+docker logs -f kimi-k3-hh-dspark
+curl -fsS http://127.0.0.1:8000/v1/models | python3 -m json.tool
+curl -fsS http://127.0.0.1:8000/v1/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "Kimi-K3-MXFP4-HH-DSpark7-BF16-DCP16-1M-KDA-MXFP8-P4096",
+    "prompt": "Write one sentence about speculative decoding.",
+    "max_tokens": 32,
+    "temperature": 0
+  }'
+```
+
+## Qualified Capacity and Throughput
+
+Measurements used 16 RTX PRO 6000 Blackwell Server Edition GPUs, TP16/DCP16,
+one active request, a 256-token prompt, and up to 1,024 generated tokens. The
+target-only protocol constrained generation to token ID 13 so model output did
+not affect per-token timing. Speculative measurements used natural greedy
+generation and report medians across six post-warmup requests.
+
+| Profile | Reported target KV tokens | Decode tok/s median | Target cycles/s median | Draft acceptance median |
+|---|---:|---:|---:|---:|
+| Target-only | 1,460,937 | 56.30 | n/a | n/a |
+| DSpark K7 | 1,057,049 | 107.24 | 30.22 | 0.364 |
+| DFlash K7 | 1,039,043 | 93.67 | 29.57 | 0.310 |
+
+The DSpark target KV allocation exceeds 1,048,576 tokens by 8,473 tokens. The
+DFlash allocation is 9,533 tokens, or 0.91%, below that exact length; vLLM
+reports 0.99 maximum concurrency for a 1,048,576-token request.
+
+Three independent Sieve coding requests produced these generation-only rates:
+
+| Profile | Runs (tok/s) | Median (tok/s) | CJK characters |
+|---|---|---:|---:|
+| DSpark K7 | 123.49, 104.01, 137.83 | 123.49 | 0 |
+| DFlash K7 | 129.04, 161.33, 159.21 | 159.21 | 0 |
+
+Coding throughput is acceptance- and output-dependent; use target cycles per
+second to compare target runtime overhead independently of generated text.
+
+InstantTensor loaded target-only weights in 163.68 seconds and completed the
+target-only model load in 186.86 seconds. The complete DSpark and DFlash model
+loads took approximately 203.0 and 196.34 seconds respectively on a warm host
+filesystem cache.
+
+## Build the Image
+
+```bash
+git clone https://github.com/local-inference-lab/blackwell-llm-docker.git
+cd blackwell-llm-docker
+git checkout build/kimi-k3-hh-pr-stack-20260811
+./build-kimi-k3-hh-runtime.sh
+```
+
+The builder verifies both integration patch hashes and resulting Git trees,
+then verifies the corresponding image labels. To publish the resulting tag in
+the same operation, set `PUSH_IMAGE=1`.
+
+## Evidence
+
+The machine-readable image receipt is
+[`validation/kimi-k3-hh-runtime-20260811.json`](https://github.com/local-inference-lab/blackwell-llm-docker/blob/build/kimi-k3-hh-pr-stack-20260811/validation/kimi-k3-hh-runtime-20260811.json).
+Full local server logs, container inspections, request summaries, and generated
+outputs are stored under:
+
+```text
+/mnt/luke/kimi-k3-runs/hh-release-20260811
+```
+
+The raw local evidence is machine-specific and is not required to rebuild the
+image; the committed lock files and validation receipt carry the durable source
+and result identities.

--- a/models/kimi-k3/README.md
+++ b/models/kimi-k3/README.md
@@ -3,10 +3,10 @@
 Status: **qualified**.
 
 This page specifies the containerized vLLM runtime for `moonshotai/Kimi-K3`
-on 16 NVIDIA RTX PRO 6000 Blackwell Server Edition GPUs. The target checkpoint
-retains its MXFP4 expert weights and uses FP8 KV cache. One image provides
-target-only decode, seven-token DSpark speculative decode, and seven-token
-DFlash speculative decode.
+on 16 NVIDIA RTX PRO 6000 Blackwell Workstation Edition GPUs. The target
+checkpoint retains its MXFP4 expert weights and uses FP8 KV cache. One image
+provides target-only decode, seven-token DSpark speculative decode, and
+seven-token DFlash speculative decode.
 
 ## Qualified Artifact
 
@@ -164,7 +164,7 @@ curl -fsS http://127.0.0.1:8000/v1/completions \
 
 ## Qualified Capacity and Decode Throughput
 
-Measurements used 16 RTX PRO 6000 Blackwell Server Edition GPUs, TP16/DCP16,
+Measurements used 16 RTX PRO 6000 Blackwell Workstation Edition GPUs, TP16/DCP16,
 one active request, a 256-token prompt, and 1,024 generated tokens. The
 target-only protocol constrained generation to token ID 13 so model output did
 not affect per-token timing. Speculative measurements used greedy sampling.

--- a/models/kimi-k3/README.md
+++ b/models/kimi-k3/README.md
@@ -200,7 +200,7 @@ the Python runtime, native extension imports, and a 16-rank NCCL collective.
 ## Evidence
 
 The machine-readable qualification receipt is
-[`validation/kimi-k3-infernal-invocation-runtime-20260812.json`](https://github.com/local-inference-lab/blackwell-llm-docker/blob/2229e9e331eaa4f6a809aabb20f76ca384016cb2/validation/kimi-k3-infernal-invocation-runtime-20260812.json).
+[`validation/kimi-k3-infernal-invocation-runtime-20260812.json`](https://github.com/local-inference-lab/blackwell-llm-docker/blob/f05633234d99a300f259ec427052d54b0a55c17e/validation/kimi-k3-infernal-invocation-runtime-20260812.json).
 Server logs, container inspections, and normalized benchmark summaries from
 the qualified host are stored under:
 

--- a/models/kimi.md
+++ b/models/kimi.md
@@ -1,14 +1,14 @@
 # Kimi Runbook Hub
 
 Use this page as the stable entry point for Kimi models on RTX PRO 6000
-Blackwell. It covers the Kimi-K3 Heraldic Harbinger TP16 runtime,
+Blackwell. It covers the Kimi-K3 Infernal Invocation TP16/DCP16 runtime,
 Kimi-K2.7-Code DFlash, and Kimi-K2.6 regression/debugging references.
 
 ## Qualified Runtime Pages
 
 | Need | Page |
 |---|---|
-| Run Kimi-K3 with a full MXFP4 target, DCP16, and target-only, DSpark, or DFlash decode | [Kimi-K3 HH TP16 runtime](kimi-k3/README.md) |
+| Run Kimi-K3 with a full MXFP4 target, DCP16, and target-only, DSpark, or DFlash decode | [Kimi-K3 TP16/DCP16 runtime](kimi-k3/README.md) |
 | Run Kimi-K2.7-Code on the Fathomless runtime | [Kimi-K2.7-Code v3](kimi-k27-code_v3.md) |
 | Reproduce the Eldritch Kimi-K2.7-Code recipe | [Kimi-K2.7-Code v2](kimi-k27-code_v2.md) |
 | Reproduce Black Benediction Kimi-K2.7-Code | [Kimi-K2.7-Code](kimi-k27-code.md) |
@@ -29,7 +29,7 @@ Kimi-K2.7-Code DFlash, and Kimi-K2.6 regression/debugging references.
 
 | Page | Status | Scope |
 |---|---|---|
-| [Kimi-K3 HH TP16 runtime](kimi-k3/README.md) | Qualified | Reproducible HH/B12X Docker image and target-only, DSpark, and DFlash profiles. |
+| [Kimi-K3 TP16/DCP16 runtime](kimi-k3/README.md) | Qualified | Reproducible Infernal Invocation/B12X Docker image and target-only, DSpark, and DFlash profiles. |
 | [Kimi-K2.7-Code v3](kimi-k27-code_v3.md) | Qualified | Fathomless Kimi DFlash validation and patch overlay notes. |
 | [Kimi-K2.7-Code v2](kimi-k27-code_v2.md) | Research-only | Eldritch Kimi runtime evidence. |
 | [Kimi-K2.7-Code](kimi-k27-code.md) | Research-only | Black Benediction recipe. |

--- a/models/kimi.md
+++ b/models/kimi.md
@@ -1,38 +1,41 @@
 # Kimi Runbook Hub
 
 Use this page as the stable entry point for Kimi models on RTX PRO 6000
-Blackwell. The Kimi pages include both current Kimi-K2.7-Code DFlash work and
-older Kimi-K2.6 regression/debugging notes.
+Blackwell. It covers the Kimi-K3 Heraldic Harbinger TP16 runtime,
+Kimi-K2.7-Code DFlash, and Kimi-K2.6 regression/debugging references.
 
-## Current Recommendation
+## Qualified Runtime Pages
 
 | Need | Page |
 |---|---|
-| Run Kimi-K2.7-Code on the current Fathomless line | [Kimi-K2.7-Code v3](kimi-k27-code_v3.md) |
+| Run Kimi-K3 with a full MXFP4 target, DCP16, and target-only, DSpark, or DFlash decode | [Kimi-K3 HH TP16 runtime](kimi-k3/README.md) |
+| Run Kimi-K2.7-Code on the Fathomless runtime | [Kimi-K2.7-Code v3](kimi-k27-code_v3.md) |
 | Reproduce the Eldritch Kimi-K2.7-Code recipe | [Kimi-K2.7-Code v2](kimi-k27-code_v2.md) |
 | Reproduce Black Benediction Kimi-K2.7-Code | [Kimi-K2.7-Code](kimi-k27-code.md) |
-| Debug older Kimi-K2.6 MTP/DFlash long-context behavior | [Kimi-K2.6 MTP long-context WIP](kimi-k26-mtp-long-ctx-wip/README.md) |
+| Research Kimi-K2.6 MTP/DFlash long-context behavior | [Kimi-K2.6 MTP long-context research](kimi-k26-mtp-long-ctx-wip/README.md) |
 
-## Current Runtime Shape
+## Runtime Interfaces
 
-| Area | Current guidance |
+| Area | Guidance |
 |---|---|
-| Current target | `moonshotai/Kimi-K2.7-Code` |
-| Draft path | DFlash, documented in the Kimi-K2.7 v3 page |
+| Kimi-K3 target | `moonshotai/Kimi-K3` at revision `2496450e92e425c886db095102a52a6682ca3970` |
+| Kimi-K3 draft paths | `Inferact/Kimi-K3-DSpark` and `modal-labs/Kimi-K3-DFlash` |
+| Kimi-K2.7-Code target | `moonshotai/Kimi-K2.7-Code` |
 | Runner | vLLM V2 |
 | Common parser setup | `--reasoning-parser kimi_k2`, `--tool-call-parser kimi_k2`, `--enable-auto-tool-choice` |
-| DCP | Use only configurations documented in the current Kimi page; older DCP/DFlash behavior had prefix-cache and metadata fixes. |
+| DCP | Use only the topology and cache contracts documented by the selected model page. |
 
 ## Version Map
 
-| Page | Status | Why keep it |
+| Page | Status | Scope |
 |---|---|---|
-| [Kimi-K2.7-Code v3](kimi-k27-code_v3.md) | Current | Fathomless Kimi DFlash validation and patch overlay notes. |
-| [Kimi-K2.7-Code v2](kimi-k27-code_v2.md) | Historical | Eldritch Kimi runtime. |
-| [Kimi-K2.7-Code](kimi-k27-code.md) | Historical | Black Benediction recipe. |
-| [Kimi-K2.6 v9](kimi-k26-v9.md) | Historical | Black Benediction DFlash baseline. |
-| [Kimi-K2.6 v2-v8](kimi-k26-v2.md) | Archive | Incremental Kimi bring-up and performance/debug history. |
-| [Kimi-K2.6 Prometheus refresh](kimi-k26-prometheus-benchmark-refresh-2026-04-25.md) | Archive | Benchmark refresh data. |
+| [Kimi-K3 HH TP16 runtime](kimi-k3/README.md) | Qualified | Reproducible HH/B12X Docker image and target-only, DSpark, and DFlash profiles. |
+| [Kimi-K2.7-Code v3](kimi-k27-code_v3.md) | Qualified | Fathomless Kimi DFlash validation and patch overlay notes. |
+| [Kimi-K2.7-Code v2](kimi-k27-code_v2.md) | Research-only | Eldritch Kimi runtime evidence. |
+| [Kimi-K2.7-Code](kimi-k27-code.md) | Research-only | Black Benediction recipe. |
+| [Kimi-K2.6 v9](kimi-k26-v9.md) | Research-only | Black Benediction DFlash baseline. |
+| [Kimi-K2.6 v2-v8](kimi-k26-v2.md) | Research-only | Kimi-K2.6 bring-up and performance/debug evidence. |
+| [Kimi-K2.6 Prometheus refresh](kimi-k26-prometheus-benchmark-refresh-2026-04-25.md) | Research-only | Benchmark refresh data. |
 
 ## Operational Reminders
 


### PR DESCRIPTION
## Documentation contract

- Defines the qualified Kimi-K3 TP16/DCP16 runtime for 16 NVIDIA RTX PRO 6000 Blackwell Workstation Edition GPUs.
- Records the immutable target, DSpark, DFlash, vLLM, B12X, Docker, base-image, and registry identifiers.
- Documents target-only, DSpark K7, and DFlash K7 launch commands with independent JIT caches.
- Distinguishes pulling the byte-identical release digest from rebuilding the pinned source composition.
- Provides the complete two-stage Docker build: the CUDA 13.3/PyTorch 2.13 base recipe followed by the Kimi-K3 runtime recipe.
- Records physical target KV capacity, normalized decode throughput, target-cycle throughput, draft acceptance, load time, and GPU-memory constraints.

## Qualified artifact

`voipmonitor/vllm:kimi-k3-infernal-vllmde04f08-b12x2e6092a-cu133-torch213-20260812-r1`

Registry digest: `sha256:974edc237f27a4eaa83a53ce4927dd176a5ad8ce4fbb8d3d689fce82348531a5`

| Profile | Physical target KV tokens | Median decode tok/s |
|---|---:|---:|
| Target-only | 1,460,937 | 56.05 |
| DSpark K7 | 1,057,049 | 118.92 |
| DFlash K7 | 1,048,576 | 89.35 |

The vLLM implementation is proposed in [local-inference-lab/vllm#284](https://github.com/local-inference-lab/vllm/pull/284). The machine-readable qualification receipt is [stored with the Docker recipe](https://github.com/local-inference-lab/blackwell-llm-docker/blob/7ae7b4ef40ed0b7c3c4cd6551ecb3dfc81578f3e/validation/kimi-k3-infernal-invocation-runtime-20260812.json).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a qualified Kimi-K3 TP16/DCP16 runtime guide, including setup, launch, validation, performance, and qualification details.
  * Updated the Kimi runbook with Kimi-K3, Kimi-K2.7-Code, and Kimi-K2.6 references.
  * Clarified runtime targets, DCP guidance, draft paths, and the scope of Qualified versus Research-only documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->