### PR TITLE
Update pcie-oneshot-allreduce.md

### DIFF
--- a/optimization/pcie-oneshot-allreduce.md
+++ b/optimization/pcie-oneshot-allreduce.md
@@ -166,7 +166,7 @@ Create `/etc/modprobe.d/nvidia-p2p-override.conf`:
 options nvidia NVreg_RegistryDwords="ForceP2P=0x11;RMForceP2PType=1;RMPcieP2PType=2;GrdmaPciTopoCheckOverride=1;EnableResizableBar=1"
 ```
 
-Then reload the nvidia driver:
+Then reload the nvidia driver. To persist in Ubuntu run update-initramfs and reboot, otherwise run: 
 
 ```bash
 # Stop everything using GPUs


### PR DESCRIPTION
In Ubuntu, to persist modprobe p2p override across reboots, run update-initramfs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified NVIDIA P2P configuration instructions for Ubuntu, including required initramfs updates and reboot steps.
  * Added guidance for other environments to reload the driver immediately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->