### PR TITLE
Add GLM-5.3 NVFP4 Jovian production stack

### DIFF
--- a/compose/glm53-flash-nvfp4-jovian-public.yml
+++ b/compose/glm53-flash-nvfp4-jovian-public.yml
@@ -1,0 +1,102 @@
+services:
+  glm53:
+    image: ghcr.io/jackzampolin/glm53-flash-nvfp4-jovian:dcp4-prefix-mtp5-e7a2a9a-b12x903667d
+    container_name: glm53-flash-nvfp4-jovian
+    restart: unless-stopped
+    init: true
+    network_mode: host
+    ipc: host
+    shm_size: 32g
+    security_opt:
+      - label=disable
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    ulimits:
+      memlock: -1
+      stack: 67108864
+      nofile:
+        soft: 1048576
+        hard: 1048576
+    environment:
+      VLLM_ENGINE_READY_TIMEOUT_S: 3600
+      VLLM_PCIE_ALLREDUCE_BACKEND: b12x
+      VLLM_B12X_MLA_CKV_GATHER: ${CKV_GATHER:-1}
+      VLLM_B12X_MLA_CKV_GATHER_MAX_TOKENS: ${CKV_GATHER_MAX_TOKENS:-524288}
+      VLLM_B12X_MLA_CKV_PREFETCH_DEPTH: ${CKV_PREFETCH_DEPTH:-0}
+      VLLM_B12X_MLA_CKV_PREFETCH_WORKSPACE_MIB: ${CKV_PREFETCH_WORKSPACE_MIB:-1024}
+      VLLM_B12X_MLA_SPEC_EXTEND_AS_DECODE: ${MTP_DECODE_PLAN:-off}
+      OMP_NUM_THREADS: 2
+      NCCL_IB_DISABLE: 1
+      # PHB is appropriate for a single-socket PCIe host. Set SYS on a
+      # dual-socket host when the GPUs span CPU sockets.
+      NCCL_P2P_LEVEL: ${NCCL_P2P_LEVEL:-PHB}
+      CUDA_DEVICE_ORDER: PCI_BUS_ID
+      CUDA_VISIBLE_DEVICES: 0,1,2,3
+    volumes:
+      - ${MODEL_DIR:?set MODEL_DIR to the downloaded checkpoint}:/model:ro
+      - ${CACHE_DIR:-./vllm-cache}:/cache
+    entrypoint: [/opt/venv/bin/vllm]
+    command:
+      - serve
+      - /model
+      - --served-model-name
+      - GLM-5.3-Flash-NVFP4
+      - --host
+      - 0.0.0.0
+      - --port
+      - "8001"
+      - --tensor-parallel-size
+      - "4"
+      - --decode-context-parallel-size
+      - "4"
+      - --cp-kv-cache-interleave-size
+      - "4"
+      - --dcp-comm-backend
+      - ag_rs
+      - --mamba-cache-mode
+      - align
+      - --enable-chunked-prefill
+      - --enable-prefix-caching
+      - --dtype
+      - bfloat16
+      - --kv-cache-dtype
+      - fp8
+      - --quantization
+      - modelopt_mixed
+      - --attention-backend
+      - B12X
+      - --block-size
+      - "256"
+      - --moe-backend
+      - humming
+      - --linear-backend
+      - b12x
+      - --no-enable-flashinfer-autotune
+      - --load-format
+      - instanttensor
+      - --gpu-memory-utilization
+      - "0.95"
+      - --max-model-len
+      - "524288"
+      - --max-num-seqs
+      - "16"
+      - --max-num-batched-tokens
+      - "4096"
+      - --reasoning-parser
+      - glm45
+      - --tool-call-parser
+      - glm47
+      - --enable-auto-tool-choice
+      - --speculative-config
+      - '{"method":"mtp","num_speculative_tokens":5,"moe_backend":"humming","attention_backend":"B12X"}'
+    healthcheck:
+      test: [CMD, curl, -fsS, http://127.0.0.1:8001/health]
+      interval: 15s
+      timeout: 5s
+      retries: 240
+      start_period: 60s

--- a/compose/glm53-flash-nvfp4-jovian.yml
+++ b/compose/glm53-flash-nvfp4-jovian.yml
@@ -1,0 +1,71 @@
+services:
+  server:
+    image: ${IMAGE:-ghcr.io/jackzampolin/glm53-flash-nvfp4-jovian:dcp4-prefix-mtp5-e7a2a9a-b12x903667d}
+    container_name: ${NAME:-glm53-flash-nvfp4-jovian}
+    restart: unless-stopped
+    network_mode: host
+    ipc: host
+    init: true
+    shm_size: 32g
+    security_opt:
+      - label=disable
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    ulimits:
+      memlock: -1
+      stack: 67108864
+      nofile:
+        soft: 1048576
+        hard: 1048576
+    environment:
+      VLLM_ENGINE_READY_TIMEOUT_S: ${VLLM_ENGINE_READY_TIMEOUT_S:-3600}
+      VLLM_PCIE_ALLREDUCE_BACKEND: b12x
+      VLLM_B12X_MLA_CKV_GATHER: ${CKV_GATHER:-1}
+      VLLM_B12X_MLA_CKV_GATHER_MAX_TOKENS: ${CKV_GATHER_MAX_TOKENS:-524288}
+      VLLM_B12X_MLA_CKV_PREFETCH_DEPTH: ${CKV_PREFETCH_DEPTH:-0}
+      VLLM_B12X_MLA_CKV_PREFETCH_WORKSPACE_MIB: ${CKV_PREFETCH_WORKSPACE_MIB:-1024}
+      # The verifier decode-plan experiment regressed C16/32k on workstation-2.
+      VLLM_B12X_MLA_SPEC_EXTEND_AS_DECODE: ${MTP_DECODE_PLAN:-off}
+      OMP_NUM_THREADS: ${OMP_NUM_THREADS:-2}
+      NCCL_IB_DISABLE: ${NCCL_IB_DISABLE:-1}
+      # Both workstations are single-socket PCIe hosts. PHB is the appropriate
+      # peer level; SYS is the workaround for dual-socket hosts.
+      NCCL_P2P_LEVEL: ${NCCL_P2P_LEVEL:-PHB}
+      CUDA_DEVICE_ORDER: PCI_BUS_ID
+      CUDA_VISIBLE_DEVICES: 0,1,2,3
+      MODEL_CONTAINER: ${MODEL_CONTAINER}
+      SERVED_MODEL_NAME: ${SERVED_MODEL_NAME:-GLM-5.3-Flash-NVFP4}
+      PORT: ${PORT:-8001}
+      TP: ${TP:-4}
+      DCP: ${DCP:-4}
+      CP_KV_CACHE_INTERLEAVE_SIZE: ${CP_KV_CACHE_INTERLEAVE_SIZE:-4}
+      DCP_COMM_BACKEND: ${DCP_COMM_BACKEND:-ag_rs}
+      PREFIX_CACHING: ${PREFIX_CACHING:-1}
+      ENFORCE_EAGER: ${ENFORCE_EAGER:-0}
+      DISABLE_CUSTOM_ALL_REDUCE: ${DISABLE_CUSTOM_ALL_REDUCE:-0}
+      NUM_SPECULATIVE_TOKENS: ${MTP:-5}
+      PER_REQUEST_SPEC_DECODE_METRICS: ${PER_REQUEST_SPEC_DECODE_METRICS:-0}
+      SPEC_ATTENTION_BACKEND: ${SPEC_ATTENTION_BACKEND:-B12X}
+      ATTENTION_BACKEND: ${ATTENTION_BACKEND:-B12X}
+      MOE_BACKEND: ${MOE_BACKEND:-humming}
+      # GLM-5.3 sets a SwiGLU clamp. Keep Humming as the qualified default.
+      # When explicitly testing B12X MoE, set this to 1 to select its
+      # clamp-preserving W4A16 activation path; native W4A4 is not equivalent.
+      B12X_MOE_FORCE_A16: ${B12X_MOE_FORCE_A16:-0}
+      MAX_NUM_SEQS: ${MAX_NUM_SEQS:-16}
+      MAX_MODEL_LEN: ${MAX_MODEL_LEN:-524288}
+      MAX_NUM_BATCHED_TOKENS: ${MAX_BATCHED_TOKENS:-4096}
+      GPU_MEMORY_UTILIZATION: ${GPU_MEMORY_UTILIZATION:-0.95}
+    volumes:
+      # Snapshot entries are symlinks into the repository-level blobs directory.
+      - ${MODEL_REPO_ROOT}:/model-cache:ro
+      - ${CACHE_DIR:-/data/vllm-cache/glm53-jovian-e7a2a9a-dcp4-mtp5-s16-b4096-humming}:/cache
+      - ../scripts/serve-glm53-flash-nvfp4-jovian.sh:/opt/local-inference/serve-glm53-flash-nvfp4-jovian.sh:ro
+    entrypoint:
+      - /bin/bash
+      - /opt/local-inference/serve-glm53-flash-nvfp4-jovian.sh

--- a/models/glm53-flash/Dockerfile.jovian-head
+++ b/models/glm53-flash/Dockerfile.jovian-head
@@ -1,0 +1,91 @@
+ARG BASE_IMAGE=voipmonitor/vllm@sha256:ef565229832e1f344fbe042dd97e950ec2cae10bc2fe7c6d158a47db840574f4
+FROM ${BASE_IMAGE}
+
+SHELL ["/bin/bash", "-euxo", "pipefail", "-c"]
+
+ARG VLLM_REPO=https://github.com/local-inference-lab/vllm.git
+ARG VLLM_COMMIT=4dbd82b9ced13114f90e93b8b6fae0966c942a3b
+ARG B12X_REPO=https://github.com/local-inference-lab/b12x.git
+ARG B12X_COMMIT=903667d36aee19320776019a31dd06d1e9255b6a
+
+RUN mkdir -p /opt/jovian-judgement \
+ && git clone --filter=blob:none --no-checkout "${VLLM_REPO}" \
+      /opt/jovian-judgement/vllm \
+ && git -C /opt/jovian-judgement/vllm fetch --depth=1 origin "${VLLM_COMMIT}" \
+ && git -C /opt/jovian-judgement/vllm checkout --detach "${VLLM_COMMIT}" \
+ && test "$(git -C /opt/jovian-judgement/vllm rev-parse HEAD)" = "${VLLM_COMMIT}" \
+ && git clone --filter=blob:none --no-checkout "${B12X_REPO}" \
+      /opt/jovian-judgement/b12x \
+ && git -C /opt/jovian-judgement/b12x fetch --depth=1 origin "${B12X_COMMIT}" \
+ && git -C /opt/jovian-judgement/b12x checkout --detach "${B12X_COMMIT}" \
+ && test "$(git -C /opt/jovian-judgement/b12x rev-parse HEAD)" = "${B12X_COMMIT}"
+
+# Preserve extension modules whose sources are unchanged, then rebuild the
+# vLLM CUDA/C++ extensions so the packed GLM-5.3 C4 cache operation matches
+# the checked-out Python implementation.
+RUN find /opt/glm53-flash/vllm/vllm -maxdepth 1 -type f -name '*.abi3.so' \
+      -exec cp -a -t /opt/jovian-judgement/vllm/vllm {} + \
+ && cp -a /opt/glm53-flash/vllm/vllm/vllm_flash_attn \
+      /opt/jovian-judgement/vllm/vllm/
+
+WORKDIR /opt/jovian-judgement/vllm
+
+RUN cmake -S . -B /tmp/jovian-vllm-extensions -G Ninja \
+      -U MARLIN_GEN_SCRIPT_HASH_AND_ARCH \
+      -U MOE_MARLIN_GEN_SCRIPT_HASH_AND_ARCH \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_CUDA_ARCHITECTURES=75 \
+      -DVLLM_TARGET_DEVICE=cuda \
+      -DVLLM_PYTHON_EXECUTABLE=/opt/venv/bin/python \
+      -DNVCC_THREADS=4 \
+ && cmake --build /tmp/jovian-vllm-extensions --parallel 24 \
+ && cmake --install /tmp/jovian-vllm-extensions \
+      --prefix /tmp/jovian-vllm-flash-attn-python \
+      --component _vllm_fa4_cutedsl_C \
+ && cp -a /tmp/jovian-vllm-flash-attn-python/vllm/vllm_flash_attn/cute \
+      /opt/jovian-judgement/vllm/vllm/vllm_flash_attn/ \
+ && flash_attn_source=/tmp/jovian-vllm-extensions/_deps/vllm-flash-attn-src/vllm_flash_attn \
+ && cp -a "${flash_attn_source}/layers" "${flash_attn_source}/ops" \
+      /opt/jovian-judgement/vllm/vllm/vllm_flash_attn/ \
+ && find /tmp/jovian-vllm-extensions -name '*.abi3.so' \
+      > /tmp/jovian-vllm-extension-list \
+ && while IFS= read -r extension; do \
+      case "${extension}" in \
+        */vllm-flash-attn/*) destination=/opt/jovian-judgement/vllm/vllm/vllm_flash_attn ;; \
+        */_deps/*) continue ;; \
+        *) destination=/opt/jovian-judgement/vllm/vllm ;; \
+      esac; \
+      cp "${extension}" "${destination}/$(basename "${extension}")"; \
+    done < /tmp/jovian-vllm-extension-list \
+ && test -f /opt/jovian-judgement/vllm/vllm/_C_stable_libtorch.abi3.so \
+ && test -f /opt/jovian-judgement/vllm/vllm/vllm_flash_attn/cute/utils.py \
+ && rm -rf /tmp/jovian-vllm-extensions \
+      /tmp/jovian-vllm-flash-attn-python \
+      /tmp/jovian-vllm-extension-list
+
+ENV PYTHONPATH=/opt/jovian-judgement/vllm:/opt/jovian-judgement/b12x:/opt/exllamav3
+ENV SPARKINFER_DIR=/opt/jovian-judgement/b12x
+ENV LOCAL_INFERENCE_CACHE_FINGERPRINT=cu133-torch213-glm53-jovian-4dbd82b-b12x903667d
+ENV XDG_CACHE_HOME=/cache/jit/cu133-torch213-glm53-jovian-4dbd82b-b12x903667d
+ENV VLLM_CACHE_ROOT=/cache/jit/cu133-torch213-glm53-jovian-4dbd82b-b12x903667d/vllm
+ENV B12X_CUTE_COMPILE_CACHE_DIR=/cache/jit/cu133-torch213-glm53-jovian-4dbd82b-b12x903667d/b12x/cute
+ENV B12X_COMPILE_CACHE_DIR=/cache/jit/cu133-torch213-glm53-jovian-4dbd82b-b12x903667d/b12x/compile
+
+RUN /opt/venv/bin/python - <<'PY'
+import pathlib
+import b12x
+import vllm
+
+assert pathlib.Path(vllm.__file__).resolve().is_relative_to(
+    pathlib.Path("/opt/jovian-judgement/vllm")
+)
+assert pathlib.Path(b12x.__file__).resolve().is_relative_to(
+    pathlib.Path("/opt/jovian-judgement/b12x")
+)
+PY
+
+LABEL org.opencontainers.image.source="https://github.com/local-inference-lab/vllm" \
+      local-inference.release.name="glm53-flash-nvfp4-jovian-head" \
+      local-inference.vllm.commit="${VLLM_COMMIT}" \
+      local-inference.b12x.commit="${B12X_COMMIT}" \
+      local-inference.runtime.parent="voipmonitor/vllm@sha256:ef565229832e1f344fbe042dd97e950ec2cae10bc2fe7c6d158a47db840574f4"

--- a/models/glm53-flash/Dockerfile.jovian-runtime
+++ b/models/glm53-flash/Dockerfile.jovian-runtime
@@ -1,0 +1,51 @@
+ARG BASE_IMAGE=local/glm53-flash-nvfp4-jovian:vllm4dbd82b-b12x903667d
+FROM ${BASE_IMAGE}
+
+SHELL ["/bin/bash", "-euxo", "pipefail", "-c"]
+
+ARG VLLM_RUNTIME_COMMIT=e7a2a9a71187550105ba182030ac4dd937227126
+ARG VLLM_RUNTIME_REPO=https://github.com/jackzampolin/vllm.git
+ARG B12X_RUNTIME_COMMIT=903667d36aee19320776019a31dd06d1e9255b6a
+ARG CACHE_FINGERPRINT=cu133-torch213-glm53-jovian-e7a2a9a-b12x903667d
+
+# The runtime commit contains Python/CuTeDSL changes only. Preserve the base
+# source tree and clone a clean runtime tree, then carry over its ABI-compatible
+# compiled extensions.
+WORKDIR /opt/jovian-judgement
+RUN mv /opt/jovian-judgement/vllm /opt/jovian-judgement/vllm-base \
+ && git clone --filter=blob:none --no-checkout "${VLLM_RUNTIME_REPO}" \
+      /opt/jovian-judgement/vllm \
+ && git -C /opt/jovian-judgement/vllm fetch --depth=1 origin "${VLLM_RUNTIME_COMMIT}" \
+ && git -C /opt/jovian-judgement/vllm checkout --detach "${VLLM_RUNTIME_COMMIT}" \
+ && test "$(git -C /opt/jovian-judgement/vllm rev-parse HEAD)" = "${VLLM_RUNTIME_COMMIT}" \
+ && find /opt/jovian-judgement/vllm-base/vllm -maxdepth 1 -type f \
+      -name '*.abi3.so' -exec cp -a -t /opt/jovian-judgement/vllm/vllm {} + \
+ && cp -a /opt/jovian-judgement/vllm-base/vllm/vllm_flash_attn \
+      /opt/jovian-judgement/vllm/vllm/
+
+ENV LOCAL_INFERENCE_CACHE_FINGERPRINT=${CACHE_FINGERPRINT}
+ENV XDG_CACHE_HOME=/cache/jit/${CACHE_FINGERPRINT}
+ENV VLLM_CACHE_ROOT=/cache/jit/${CACHE_FINGERPRINT}/vllm
+ENV B12X_CUTE_COMPILE_CACHE_DIR=/cache/jit/${CACHE_FINGERPRINT}/b12x/cute
+ENV B12X_COMPILE_CACHE_DIR=/cache/jit/${CACHE_FINGERPRINT}/b12x/compile
+
+WORKDIR /opt/jovian-judgement/vllm
+
+RUN /opt/venv/bin/python - <<'PY'
+import pathlib
+import b12x
+import vllm
+
+assert pathlib.Path(vllm.__file__).resolve().is_relative_to(
+    pathlib.Path("/opt/jovian-judgement/vllm")
+)
+assert pathlib.Path(b12x.__file__).resolve().is_relative_to(
+    pathlib.Path("/opt/jovian-judgement/b12x")
+)
+PY
+
+LABEL org.opencontainers.image.source="https://github.com/jackzampolin/vllm" \
+      local-inference.release.name="glm53-flash-nvfp4-jovian-runtime" \
+      local-inference.vllm.commit="${VLLM_RUNTIME_COMMIT}" \
+      local-inference.vllm.extension-commit="4dbd82b9ced13114f90e93b8b6fae0966c942a3b" \
+      local-inference.b12x.commit="${B12X_RUNTIME_COMMIT}"

--- a/models/glm53-flash/README.md
+++ b/models/glm53-flash/README.md
@@ -1,0 +1,84 @@
+# GLM-5.3-Flash NVFP4 Jovian runtime
+
+This stack overlays the GLM-5.3 DCP, CKV, prefix-cache, and speculative-decode
+runtime changes on the CUDA 13.3 / Torch 2.13 / B12X image. The build is split
+so Python-only vLLM changes rebuild a small runtime overlay without rebuilding
+the compiled extensions.
+
+## Source pins
+
+- vLLM extensions: `4dbd82b9ced13114f90e93b8b6fae0966c942a3b`
+- vLLM runtime: `e7a2a9a71187550105ba182030ac4dd937227126`
+- B12X extensions: `903667d36aee19320776019a31dd06d1e9255b6a`
+- B12X runtime: `903667d36aee19320776019a31dd06d1e9255b6a`
+- Parent image: `voipmonitor/vllm@sha256:ef565229832e1f344fbe042dd97e950ec2cae10bc2fe7c6d158a47db840574f4`
+
+Later branch heads `d43a0aa8` (vLLM) and `34505bcf` (B12X), checked on
+2026-08-27, only add Qwen runtime/kernels and do not change GLM-5.3.
+
+## Build and serve
+
+```bash
+./scripts/build-glm53-jovian-head-image.sh
+STACK=jovian ./scripts/run-glm53-flash-nvfp4-compose.sh up
+```
+
+The qualified target is TP4/DCP4, MTP5, FP8 KV, prefix caching, a 524,288-token
+maximum model length, B12X sparse attention/linear/all-reduce, CKV gather, and
+Humming MoE. The defaults use graph mode, 16 maximum sequences, a 4,096-token
+batch ceiling, and 0.95 GPU-memory utilization. Use a cache directory specific
+to the source and configuration while qualifying a new image:
+
+```bash
+CACHE_DIR=/data/vllm-cache/glm53-jovian-e7a2a9a-dcp4-mtp5 \
+  STACK=jovian \
+  ./scripts/run-glm53-flash-nvfp4-compose.sh up
+```
+
+Humming is the correctness-preserving MoE default. GLM-5.3 applies a SwiGLU
+clamp that native B12X W4A4 does not currently reproduce. The optional
+`B12X_MOE_FORCE_A16=1 MOE_BACKEND=b12x` path preserves that clamp, but measured
+slower than Humming and is not the production default.
+
+## Qualified results
+
+On a stock-clock 4x RTX PRO 6000 Blackwell workstation, the 0.95 configuration
+completed the C16/8k regression load without an OOM or container restart. vLLM
+reported 14,034,786 usable KV tokens after hybrid-cache reservations (26.77
+concurrent 524,288-token requests). The benchmark's raw DCP-scaled block count
+is larger and must not be reported as usable capacity.
+
+A focused run measured 7,306/8,208/8,154 tok/s prefill at 8k/64k/128k.
+Sustained zero-context aggregate decode at C1/C8/C16 was
+128.1/575.7/792.0 tok/s. These are initial qualification numbers, not the
+>10k prefill or >170 C1 decode performance target. MTP acceptance is
+workload-dependent: observed effective output per verification step ranged
+from 2.50 on two coding/operations prompts to 2.84-2.96 on synthetic load;
+an earlier Rust sample on the experimental lineage reached 3.37.
+
+The exact published image is
+`ghcr.io/jackzampolin/glm53-flash-nvfp4-jovian:dcp4-prefix-mtp5-e7a2a9a-b12x903667d`
+with digest
+`sha256:8e621a7e381f46a56ece6e6b794a38fc5f0ddf18c7d1d507d54267367c02699d`.
+The corresponding vLLM review is
+[`local-inference-lab/vllm#488`](https://github.com/local-inference-lab/vllm/pull/488).
+
+## Validate
+
+```bash
+curl -fsS http://127.0.0.1:8001/health
+curl -sS http://127.0.0.1:8001/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"GLM-5.3-Flash-NVFP4","messages":[{"role":"user","content":"Say OK."}],"max_tokens":128,"temperature":0}' | jq .
+```
+
+Confirm that `vllm:spec_decode_num_accepted_tokens_total` increases, and retain
+the startup lines for model memory, KV tokens, maximum 524k concurrency, DCP4
+groups, B12X PCIe all-reduce, and CKV query selection. Per-request speculative
+metrics are disabled by default to avoid perturbing the production path.
+
+For the standard endpoint characterization from a workstation:
+
+```bash
+B=~/llm-inference-bench; $B/.venv/bin/python $B/llm_decode_bench.py --port 8001 --model GLM-5.3-Flash-NVFP4 --standalone-prefill --prefill-contexts 8k,64k,128k,256k,512k --contexts 0,8k,16k,32k --concurrency 1,2,4,8,16,32 --duration 30 --max-tokens 4096 --run-burst --output ~/glm53-$(hostname)-$(date -u +%Y%m%dT%H%M%SZ).json
+```

--- a/models/glm53-flash/README.md
+++ b/models/glm53-flash/README.md
@@ -56,6 +56,17 @@ workload-dependent: observed effective output per verification step ranged
 from 2.50 on two coding/operations prompts to 2.84-2.96 on synthetic load;
 an earlier Rust sample on the experimental lineage reached 3.37.
 
+Two stock-clock tuning probes establish the current safe defaults:
+
+- CKV prefetch depth 1 reserved 1,190.3 MiB/GPU for two MTP execution lanes,
+  reduced usable KV to 13,456,725 tokens, and measured
+  7,376/8,228/8,174 tok/s prefill. The noise-level gain does not justify the
+  memory and startup-pressure cost, so the default remains depth 0.
+- Raising `--max-num-batched-tokens` to 8,192 increased estimated graph memory
+  to 16.95 GiB/GPU, reduced usable KV to 9,464,070 tokens, and failed during
+  Humming graph capture with a TMA illegal-memory-access error. The qualified
+  ceiling remains 4,096 for this image.
+
 The exact published image is
 `ghcr.io/jackzampolin/glm53-flash-nvfp4-jovian:dcp4-prefix-mtp5-e7a2a9a-b12x903667d`
 with digest

--- a/scripts/build-glm53-jovian-head-image.sh
+++ b/scripts/build-glm53-jovian-head-image.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VLLM_COMMIT="${VLLM_COMMIT:-4dbd82b9ced13114f90e93b8b6fae0966c942a3b}"
+B12X_COMMIT="${B12X_COMMIT:-903667d36aee19320776019a31dd06d1e9255b6a}"
+VLLM_RUNTIME_COMMIT="${VLLM_RUNTIME_COMMIT:-e7a2a9a71187550105ba182030ac4dd937227126}"
+VLLM_RUNTIME_REPO="${VLLM_RUNTIME_REPO:-https://github.com/jackzampolin/vllm.git}"
+B12X_RUNTIME_COMMIT="${B12X_RUNTIME_COMMIT:-903667d36aee19320776019a31dd06d1e9255b6a}"
+CACHE_FINGERPRINT="${CACHE_FINGERPRINT:-cu133-torch213-glm53-jovian-${VLLM_RUNTIME_COMMIT:0:7}-b12x${B12X_RUNTIME_COMMIT:0:7}}"
+BASE_IMAGE="${BASE_IMAGE:-local/glm53-flash-nvfp4-jovian:vllm${VLLM_COMMIT:0:7}-b12x${B12X_COMMIT:0:7}}"
+IMAGE="${IMAGE:-local/glm53-flash-nvfp4-jovian:${VLLM_RUNTIME_COMMIT:0:7}-b12x${B12X_RUNTIME_COMMIT:0:7}}"
+
+if ! docker image inspect "${BASE_IMAGE}" >/dev/null 2>&1; then
+  DOCKER_BUILDKIT=1 docker build \
+    --progress=plain \
+    --build-arg VLLM_COMMIT="${VLLM_COMMIT}" \
+    --build-arg B12X_COMMIT="${B12X_COMMIT}" \
+    --tag "${BASE_IMAGE}" \
+    --file "${ROOT_DIR}/models/glm53-flash/Dockerfile.jovian-head" \
+    "${ROOT_DIR}"
+fi
+
+DOCKER_BUILDKIT=1 docker build \
+  --progress=plain \
+  --build-arg BASE_IMAGE="${BASE_IMAGE}" \
+  --build-arg VLLM_RUNTIME_REPO="${VLLM_RUNTIME_REPO}" \
+  --build-arg VLLM_RUNTIME_COMMIT="${VLLM_RUNTIME_COMMIT}" \
+  --build-arg B12X_RUNTIME_COMMIT="${B12X_RUNTIME_COMMIT}" \
+  --build-arg CACHE_FINGERPRINT="${CACHE_FINGERPRINT}" \
+  --tag "${IMAGE}" \
+  --file "${ROOT_DIR}/models/glm53-flash/Dockerfile.jovian-runtime" \
+  "${ROOT_DIR}"
+
+docker image inspect "${IMAGE}" >/dev/null
+printf 'image=%s\n' "${IMAGE}"

--- a/scripts/run-glm53-flash-nvfp4-compose.sh
+++ b/scripts/run-glm53-flash-nvfp4-compose.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+STACK="${STACK:-chris}"
+
+case "${STACK}" in
+  chris)
+    DEFAULT_COMPOSE_FILE="${ROOT_DIR}/compose/glm53-flash-nvfp4.yml"
+    DEFAULT_IMAGE="cstechdev/vllm@sha256:0bd709e80b8ff13ae5de8f7d7f708a499fade3a26970d56afb1be2ff3860fde5"
+    DEFAULT_NAME="glm53-flash-nvfp4-chris"
+    DEFAULT_DCP=1
+    DEFAULT_CP_KV_CACHE_INTERLEAVE_SIZE=1
+    # The pinned cstech image cannot map the current checkpoint's MTP scales.
+    DEFAULT_MTP=0
+    DEFAULT_MAX_NUM_SEQS=16
+    DEFAULT_MAX_MODEL_LEN=524288
+    DEFAULT_MAX_BATCHED_TOKENS=8192
+    DEFAULT_GPU_MEMORY_UTILIZATION=0.95
+    DEFAULT_CACHE_DIR=/data/vllm-cache/glm53-flash-nvfp4-chris
+    ;;
+  festr)
+    DEFAULT_COMPOSE_FILE="${ROOT_DIR}/compose/glm53-flash-nvfp4-festr.yml"
+    DEFAULT_IMAGE="voipmonitor/vllm@sha256:ef565229832e1f344fbe042dd97e950ec2cae10bc2fe7c6d158a47db840574f4"
+    DEFAULT_NAME="glm53-flash-nvfp4-festr"
+    DEFAULT_DCP=1
+    DEFAULT_CP_KV_CACHE_INTERLEAVE_SIZE=1
+    DEFAULT_MTP=0
+    DEFAULT_MAX_NUM_SEQS=16
+    DEFAULT_MAX_MODEL_LEN=524288
+    DEFAULT_MAX_BATCHED_TOKENS=8192
+    DEFAULT_GPU_MEMORY_UTILIZATION=0.95
+    DEFAULT_CACHE_DIR=/data/vllm-cache/glm53-flash-nvfp4-festr
+    ;;
+  jovian)
+    DEFAULT_COMPOSE_FILE="${ROOT_DIR}/compose/glm53-flash-nvfp4-jovian.yml"
+    DEFAULT_IMAGE="ghcr.io/jackzampolin/glm53-flash-nvfp4-jovian:dcp4-prefix-mtp5-e7a2a9a-b12x903667d"
+    DEFAULT_NAME="glm53-flash-nvfp4-jovian"
+    DEFAULT_DCP=4
+    DEFAULT_CP_KV_CACHE_INTERLEAVE_SIZE=4
+    DEFAULT_MTP=5
+    DEFAULT_MAX_NUM_SEQS=16
+    DEFAULT_MAX_MODEL_LEN=524288
+    DEFAULT_MAX_BATCHED_TOKENS=4096
+    DEFAULT_GPU_MEMORY_UTILIZATION=0.95
+    DEFAULT_CACHE_DIR=/data/vllm-cache/glm53-jovian-e7a2a9a-dcp4-mtp5-s16-b4096-humming
+    ;;
+  *)
+    printf 'ERROR: STACK must be chris, festr, or jovian; got %s\n' "${STACK}" >&2
+    exit 2
+    ;;
+esac
+
+COMPOSE_FILE="${COMPOSE_FILE:-${DEFAULT_COMPOSE_FILE}}"
+
+MODEL_REPO_ROOT="${MODEL_REPO_ROOT:-/data/models/models--local-inference-lab--GLM-5.3-Flash-NVFP4}"
+MODEL_REVISION="${MODEL_REVISION:-520de24eabf507659eaef7c70f14fd584527facc}"
+MODEL="${MODEL:-${MODEL_REPO_ROOT}/snapshots/${MODEL_REVISION}}"
+MODEL_CONTAINER="${MODEL_CONTAINER:-/model-cache/snapshots/${MODEL_REVISION}}"
+IMAGE="${IMAGE:-${DEFAULT_IMAGE}}"
+NAME="${NAME:-${DEFAULT_NAME}}"
+SERVED_MODEL_NAME="${SERVED_MODEL_NAME:-GLM-5.3-Flash-NVFP4}"
+PORT="${PORT:-8001}"
+TP="${TP:-4}"
+DCP="${DCP:-${DEFAULT_DCP}}"
+CP_KV_CACHE_INTERLEAVE_SIZE="${CP_KV_CACHE_INTERLEAVE_SIZE:-${DEFAULT_CP_KV_CACHE_INTERLEAVE_SIZE}}"
+DCP_COMM_BACKEND="${DCP_COMM_BACKEND:-ag_rs}"
+PREFIX_CACHING="${PREFIX_CACHING:-1}"
+ENFORCE_EAGER="${ENFORCE_EAGER:-0}"
+MTP="${MTP:-${DEFAULT_MTP}}"
+MAX_NUM_SEQS="${MAX_NUM_SEQS:-${DEFAULT_MAX_NUM_SEQS}}"
+MAX_MODEL_LEN="${MAX_MODEL_LEN:-${DEFAULT_MAX_MODEL_LEN}}"
+MAX_BATCHED_TOKENS="${MAX_BATCHED_TOKENS:-${DEFAULT_MAX_BATCHED_TOKENS}}"
+GPU_MEMORY_UTILIZATION="${GPU_MEMORY_UTILIZATION:-${DEFAULT_GPU_MEMORY_UTILIZATION}}"
+CACHE_DIR="${CACHE_DIR:-${DEFAULT_CACHE_DIR}}"
+ACTION="${1:-up}"
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 2
+}
+
+[[ "${TP}" == "4" ]] || die "TP must be 4 for the symmetric workstation deployment"
+[[ "${DCP}" =~ ^(1|2|4)$ ]] || die "DCP must be 1, 2, or 4"
+[[ "${CP_KV_CACHE_INTERLEAVE_SIZE}" =~ ^[0-9]+$ ]] || \
+  die "CP_KV_CACHE_INTERLEAVE_SIZE must be an integer"
+((CP_KV_CACHE_INTERLEAVE_SIZE > 0)) || \
+  die "CP_KV_CACHE_INTERLEAVE_SIZE must be positive"
+[[ "${DCP_COMM_BACKEND}" =~ ^(ag_rs|a2a)$ ]] || \
+  die "DCP_COMM_BACKEND must be ag_rs or a2a"
+[[ "${PREFIX_CACHING}" =~ ^[01]$ ]] || die "PREFIX_CACHING must be 0 or 1"
+[[ "${ENFORCE_EAGER}" =~ ^[01]$ ]] || die "ENFORCE_EAGER must be 0 or 1"
+[[ "${MTP}" =~ ^[0-9]+$ ]] || die "MTP must be an integer"
+[[ "${MAX_NUM_SEQS}" =~ ^[0-9]+$ ]] || die "MAX_NUM_SEQS must be an integer"
+[[ "${MAX_MODEL_LEN}" =~ ^[0-9]+$ ]] || die "MAX_MODEL_LEN must be an integer"
+[[ "${MAX_BATCHED_TOKENS}" =~ ^[0-9]+$ ]] || die "MAX_BATCHED_TOKENS must be an integer"
+
+if [[ "${ACTION}" =~ ^(up|start|restart|config)$ ]] && [[ ! -f "${MODEL}/config.json" ]]; then
+  die "MODEL does not look like a local HF checkpoint: ${MODEL}"
+fi
+
+mkdir -p "${CACHE_DIR}"
+
+export MODEL MODEL_REPO_ROOT MODEL_REVISION MODEL_CONTAINER
+export IMAGE NAME SERVED_MODEL_NAME PORT TP DCP MTP MAX_NUM_SEQS STACK
+export CP_KV_CACHE_INTERLEAVE_SIZE DCP_COMM_BACKEND PREFIX_CACHING
+export ENFORCE_EAGER
+export MAX_MODEL_LEN MAX_BATCHED_TOKENS GPU_MEMORY_UTILIZATION CACHE_DIR
+
+compose=(docker compose -p "${NAME}" -f "${COMPOSE_FILE}")
+case "${ACTION}" in
+  up|start)
+    "${compose[@]}" up -d --remove-orphans
+    ;;
+  restart)
+    "${compose[@]}" up -d --force-recreate --remove-orphans
+    ;;
+  down|stop)
+    "${compose[@]}" down
+    ;;
+  logs)
+    "${compose[@]}" logs -f --tail=200
+    ;;
+  ps|config)
+    "${compose[@]}" "${ACTION}"
+    ;;
+  *)
+    die "usage: $0 [up|restart|down|logs|ps|config]"
+    ;;
+esac
+
+printf '%s\n' \
+  "stack=${STACK}" \
+  "name=${NAME}" \
+  "image=${IMAGE}" \
+  "model=${MODEL}" \
+  "model_repo_root=${MODEL_REPO_ROOT}" \
+  "model_container=${MODEL_CONTAINER}" \
+  "port=${PORT}" \
+  "tp=${TP}" \
+  "dcp=${DCP}" \
+  "cp_kv_cache_interleave_size=${CP_KV_CACHE_INTERLEAVE_SIZE}" \
+  "dcp_comm_backend=${DCP_COMM_BACKEND}" \
+  "prefix_caching=${PREFIX_CACHING}" \
+  "enforce_eager=${ENFORCE_EAGER}" \
+  "mtp=${MTP}" \
+  "max_num_seqs=${MAX_NUM_SEQS}" \
+  "max_model_len=${MAX_MODEL_LEN}" \
+  "max_batched_tokens=${MAX_BATCHED_TOKENS}" \
+  "gpu_memory_utilization=${GPU_MEMORY_UTILIZATION}" \
+  "cache_dir=${CACHE_DIR}"

--- a/scripts/serve-glm53-flash-nvfp4-jovian.sh
+++ b/scripts/serve-glm53-flash-nvfp4-jovian.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+model=${MODEL_CONTAINER:-${MODEL:-local-inference-lab/GLM-5.3-Flash-NVFP4}}
+served_model_name=${SERVED_MODEL_NAME:-GLM-5.3-Flash-NVFP4}
+port=${PORT:-8001}
+tp=${TP:-4}
+dcp=${DCP:-4}
+cp_kv_cache_interleave_size=${CP_KV_CACHE_INTERLEAVE_SIZE:-4}
+dcp_comm_backend=${DCP_COMM_BACKEND:-ag_rs}
+prefix_caching=${PREFIX_CACHING:-1}
+enforce_eager=${ENFORCE_EAGER:-0}
+disable_custom_all_reduce=${DISABLE_CUSTOM_ALL_REDUCE:-0}
+per_request_spec_decode_metrics=${PER_REQUEST_SPEC_DECODE_METRICS:-0}
+spec_attention_backend=${SPEC_ATTENTION_BACKEND:-B12X}
+attention_backend=${ATTENTION_BACKEND:-B12X}
+moe_backend=${MOE_BACKEND:-humming}
+max_num_seqs=${MAX_NUM_SEQS:-16}
+max_model_len=${MAX_MODEL_LEN:-524288}
+max_num_batched_tokens=${MAX_NUM_BATCHED_TOKENS:-4096}
+gpu_memory_utilization=${GPU_MEMORY_UTILIZATION:-0.95}
+num_speculative_tokens=${NUM_SPECULATIVE_TOKENS:-5}
+
+[[ "${num_speculative_tokens}" =~ ^[0-9]+$ ]] || {
+  printf 'NUM_SPECULATIVE_TOKENS must be a non-negative integer; got %s\n' \
+    "${num_speculative_tokens}" >&2
+  exit 2
+}
+[[ "${prefix_caching}" =~ ^[01]$ ]] || {
+  printf 'PREFIX_CACHING must be 0 or 1; got %s\n' "${prefix_caching}" >&2
+  exit 2
+}
+[[ "${enforce_eager}" =~ ^[01]$ ]] || {
+  printf 'ENFORCE_EAGER must be 0 or 1; got %s\n' "${enforce_eager}" >&2
+  exit 2
+}
+[[ "${disable_custom_all_reduce}" =~ ^[01]$ ]] || {
+  printf 'DISABLE_CUSTOM_ALL_REDUCE must be 0 or 1; got %s\n' \
+    "${disable_custom_all_reduce}" >&2
+  exit 2
+}
+[[ "${per_request_spec_decode_metrics}" =~ ^[01]$ ]] || {
+  printf 'PER_REQUEST_SPEC_DECODE_METRICS must be 0 or 1; got %s\n' \
+    "${per_request_spec_decode_metrics}" >&2
+  exit 2
+}
+
+cmd=(
+  /opt/venv/bin/vllm serve "${model}"
+  --served-model-name "${served_model_name}"
+  --host 0.0.0.0
+  --port "${port}"
+  --tensor-parallel-size "${tp}"
+  --pipeline-parallel-size 1
+  --decode-context-parallel-size "${dcp}"
+  --cp-kv-cache-interleave-size "${cp_kv_cache_interleave_size}"
+  --dcp-comm-backend "${dcp_comm_backend}"
+  --mamba-cache-mode align
+  --enable-chunked-prefill
+  --dtype bfloat16
+  --kv-cache-dtype fp8
+  --quantization modelopt_mixed
+  --attention-backend "${attention_backend}"
+  --block-size 256
+  --moe-backend "${moe_backend}"
+  --linear-backend b12x
+  --no-enable-flashinfer-autotune
+  --load-format instanttensor
+  --gpu-memory-utilization "${gpu_memory_utilization}"
+  --max-model-len "${max_model_len}"
+  --max-num-seqs "${max_num_seqs}"
+  --max-num-batched-tokens "${max_num_batched_tokens}"
+  --reasoning-parser glm45
+  --tool-call-parser glm47
+  --enable-auto-tool-choice
+)
+
+if ((disable_custom_all_reduce)); then
+  cmd+=(--disable-custom-all-reduce)
+fi
+
+if ((prefix_caching)); then
+  cmd+=(--enable-prefix-caching)
+else
+  cmd+=(--no-enable-prefix-caching)
+fi
+
+if ((enforce_eager)); then
+  cmd+=(--enforce-eager)
+fi
+
+if ((num_speculative_tokens > 0)); then
+  printf -v speculative_config \
+    '{"method":"mtp","num_speculative_tokens":%s,"moe_backend":"humming","attention_backend":"%s"}' \
+    "${num_speculative_tokens}" "${spec_attention_backend}"
+  cmd+=(--speculative-config "${speculative_config}")
+  if ((per_request_spec_decode_metrics)); then
+    cmd+=(--per-request-spec-decode-metrics summary)
+  fi
+fi
+
+if [[ "${DRY_RUN:-0}" == 1 ]]; then
+  printf 'GLM-5.3-Flash NVFP4 Jovian launch:'
+  printf ' %q' "${cmd[@]}"
+  printf '\n'
+  exit 0
+fi
+
+exec "${cmd[@]}"


### PR DESCRIPTION
## Summary

Add the reproducible GLM-5.3-Flash NVFP4 production/canary stack for four RTX PRO 6000 Blackwell GPUs:

- exact published GHCR image and source pins
- TP4 + DCP4 + MTP5
- B12X attention, linear, and PCIe all-reduce
- full CKV gather/prefetch path
- FP8 KV and prefix caching
- graph mode, Humming MoE, 524288 max context
- host and public Compose surfaces plus build/serve scripts
- stock-clock qualification evidence and benchmark command

The corresponding draft vLLM change is local-inference-lab/vllm#488.

## Validation

- `bash -n` passed for all three scripts
- `shellcheck` passed for all three scripts
- both Compose files pass `docker compose config -q`
- ws2 rendered config confirms B12X, DCP4, MTP5, prefix caching, the exact image, and the qualified cache directory
- live ws2 digest: `sha256:8e621a7e381f46a56ece6e6b794a38fc5f0ddf18c7d1d507d54267367c02699d`
- live ws2 is healthy with zero restarts/OOM
- usable KV capacity: 14,034,786 tokens
- focused prefill: 7,306 / 8,208 / 8,154 tok/s at 8k / 64k / 128k
- zero-context aggregate decode: 128.1 / 575.7 / 792.0 tok/s at C1 / C8 / C16

AI assistance disclosure: Codex prepared and validated this stack. The source PR remains draft pending human line-by-line review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for serving the GLM-5.3-Flash NVFP4 model with optimized GPU runtime configurations.
  * Added Docker Compose deployments for multiple Jovian stack variants.
  * Added configurable launchers for building images, starting services, managing deployments, and running the model server.
  * Added health checks, dry-run support, runtime configuration overrides, and deployment status commands.

* **Documentation**
  * Added setup, build, serving, validation, benchmarking, and endpoint usage documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->