### PR TITLE
Add Qwen3.8 Flash Next TP2 recipes

### DIFF
--- a/INDEX.md
+++ b/INDEX.md
@@ -145,6 +145,7 @@ python3 scripts/generate-wiki-index.py > INDEX.md
 - [Qwen3.5 Smaller Variants (27B, 35B, 122B) on RTX PRO 6000 Blackwell](models/qwen35-27b.md) - `models/qwen35-27b.md`
 - [Qwen3.5-397B-A17B on RTX PRO 6000 Blackwell](models/qwen35-397b.md) - `models/qwen35-397b.md`
 - [Qwen3.8-27B on RTX PRO 6000 Blackwell](models/qwen38-27b.md) - `models/qwen38-27b.md`
+- [Qwen3.8-Flash-Next On Two RTX PRO 6000 Blackwell GPUs](models/qwen38-flash-next.md) - `models/qwen38-flash-next.md`
 - [Qwen3.8-27B QSRT K5 dense-MLP recovery](models/qwen38-qsrt-k5-r16.md) - `models/qwen38-qsrt-k5-r16.md`
 - [Qwen3.8-27B QSRT K5 recovery: what the training result means](models/qwen38-qsrt-k5-training-result.md) - `models/qwen38-qsrt-k5-training-result.md`
 - [Xiaomi MiMo V2.5 Pro FP4-DFlash](models/xiaomi-mimo-v2.5-pro-fp4-dflash.md) - `models/xiaomi-mimo-v2.5-pro-fp4-dflash.md`

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ If you just want to run a model, use these stable hub pages first:
 | Kimi | [Kimi Runbook Hub](models/kimi.md) | Kimi-K2.7-Code, DFlash, parser/tool-call runtime. |
 | Xiaomi MiMo | [MiMo Runbook Hub](models/mimo.md) | MiMo V2.5 Pro FP4-DFlash. |
 | Qwen3.8-27B | [Qwen3.8-27B on RTX PRO 6000 Blackwell](models/qwen38-27b.md), [readable QSRT K5 training result](models/qwen38-qsrt-k5-training-result.md), [exact QSRT K5 specification](models/qwen38-qsrt-k5-r16.md) | TP1, TP2, and TP4 throughput evidence plus the QSRT K5 training interpretation, artifact, fidelity, runtime, and source contract. |
+| Qwen3.8-Flash-Next | [Qwen3.8-Flash-Next on two RTX PRO 6000 Blackwell GPUs](models/qwen38-flash-next.md) | vLLM TP2 FP8 and NVFP4 launch recipes, PLE offload, and NVFP4 loader patch. |
 | GLM-5.1 | [GLM-5.1 Runbook Hub](models/glm-5.1.md) | Historical GLM-5.1, KLD methodology, older B12X/SGLang work. |
 | Legacy / secondary models | [Legacy Model Runbooks](models/legacy.md) | DeepSeek-V4-Pro, GLM-4.7, Qwen, MiniMax, older Kimi pages. |
 

--- a/compose/qwen38-flash-next-fp8-tp2.yml
+++ b/compose/qwen38-flash-next-fp8-tp2.yml
@@ -1,0 +1,45 @@
+services:
+  vllm:
+    image: vllm/vllm-openai:qwen38-flash-next
+    container_name: vllm-qwen38-flash-fp8
+    ports:
+      - "18005:8000"
+    volumes:
+      - ${HOME}/.cache/huggingface:/root/.cache/huggingface
+    shm_size: "62g"
+    mem_limit: "62g"
+    memswap_limit: "62g"
+    runtime: nvidia
+    cap_add:
+      - SYS_PTRACE
+    environment:
+      HUGGING_FACE_HUB_TOKEN: ${HUGGING_FACE_HUB_TOKEN:-}
+      CUDA_VISIBLE_DEVICES: "0,1"
+      CUDA_DEVICE_ORDER: PCI_BUS_ID
+      TORCH_CUDA_ARCH_LIST: "12.0f"
+      PYTORCH_ALLOC_CONF: expandable_segments:True
+      VLLM_PLE_CPU_OFFLOAD: "1"
+    command:
+      - --model
+      - Qwen/Qwen3.8-Flash-Next-FP8
+      - --served-model-name
+      - qwen3.8-flash
+      - --enable-prefix-caching
+      - --tensor-parallel-size
+      - "2"
+      - --disable-custom-all-reduce
+      - --gpu-memory-utilization
+      - "0.97"
+      - --max-model-len
+      - "262144"
+      - --max-num-seqs
+      - "4"
+      - --max-num-batched-tokens
+      - "8192"
+      - --reasoning-parser
+      - qwen3
+      - --tool-call-parser
+      - qwen3_coder
+      - --enable-auto-tool-choice
+      - --speculative-config
+      - '{"method": "mtp", "num_speculative_tokens": 3}'

--- a/compose/qwen38-flash-next-nvfp4-tp2.yml
+++ b/compose/qwen38-flash-next-nvfp4-tp2.yml
@@ -1,0 +1,51 @@
+services:
+  vllm:
+    build:
+      context: ..
+      dockerfile: patches/qwen38-flash-next-nvfp4.Dockerfile
+    image: local/qwen38-flash-next-nvfp4:latest
+    container_name: vllm-qwen38-flash-nvfp4
+    ports:
+      - "18005:8000"
+    volumes:
+      - ${HOME}/.cache/huggingface:/root/.cache/huggingface
+    shm_size: "62g"
+    mem_limit: "62g"
+    memswap_limit: "62g"
+    runtime: nvidia
+    cap_add:
+      - SYS_PTRACE
+    environment:
+      HUGGING_FACE_HUB_TOKEN: ${HUGGING_FACE_HUB_TOKEN:-}
+      CUDA_VISIBLE_DEVICES: "0,1"
+      CUDA_DEVICE_ORDER: PCI_BUS_ID
+      TORCH_CUDA_ARCH_LIST: "12.0f"
+      PYTORCH_ALLOC_CONF: expandable_segments:True
+      VLLM_PLE_CPU_OFFLOAD: "1"
+    command:
+      - --model
+      - RadixArk/Qwen3.8-Flash-Next-NVFP4
+      - --served-model-name
+      - qwen3.8-flash
+      - --enable-prefix-caching
+      - --tensor-parallel-size
+      - "2"
+      - --disable-custom-all-reduce
+      - --gpu-memory-utilization
+      - "0.97"
+      - --max-model-len
+      - "262144"
+      - --max-num-seqs
+      - "4"
+      - --max-num-batched-tokens
+      - "8192"
+      - --reasoning-parser
+      - qwen3
+      - --tool-call-parser
+      - qwen3_coder
+      - --enable-auto-tool-choice
+      - --no-enable-flashinfer-autotune
+      - --compilation-config
+      - '{"mode":0,"cudagraph_mode":"full_decode_only"}'
+      - --speculative-config
+      - '{"method": "mtp", "num_speculative_tokens": 3}'

--- a/models/qwen38-flash-next.md
+++ b/models/qwen38-flash-next.md
@@ -1,0 +1,106 @@
+# Qwen3.8-Flash-Next On Two RTX PRO 6000 Blackwell GPUs
+
+This runbook provides two vLLM recipes for two 96 GiB RTX PRO 6000 Blackwell
+GPUs connected through PCIe, using Tensor Parallelism (TP) 2:
+
+| Recipe | Checkpoint | Image path | Status |
+|---|---|---|---|
+| [FP8](#fp8-recipe) | `Qwen/Qwen3.8-Flash-Next-FP8` | Official preview image | Boot and API smoke test validated |
+| [NVFP4](#nvfp4-recipe) | `RadixArk/Qwen3.8-Flash-Next-NVFP4` | Same image plus local PLE patch | Boot and API smoke test validated |
+
+These are reproducible launch configurations, not throughput benchmarks.
+They were validated with vLLM image
+`vllm/vllm-openai:qwen38-flash-next`, reported by the server as
+`0.1.dev20073+g8e685d198`. Revalidate both recipes after changing the image,
+model revision, driver, or vLLM release line.
+
+## Shared Requirements
+
+- Two NVIDIA RTX PRO 6000 Blackwell GPUs with 96 GiB VRAM each.
+- Docker with the NVIDIA Container Toolkit and access to GPUs 0 and 1.
+- At least 62 GiB of container memory available for the Position Learning
+  Enhancement (PLE) CPU offload worker. The N-gram embedding is materialized
+  in host RAM, not paged to an SSD by this recipe.
+- A Hugging Face cache mount. Authenticate before the first download when the
+  model repository requires it, for example with `huggingface-cli login`.
+
+Both recipes publish port 18005 and use both GPUs. Do not run them at the same
+time.
+
+## FP8 Recipe
+
+The official FP8 checkpoint selects vLLM's native FP8 PLE embedding path. It
+does not need a Python source override or a checkpoint conversion.
+
+```bash
+docker compose -f compose/qwen38-flash-next-fp8-tp2.yml up -d
+```
+
+The recipe intentionally retains three operational settings:
+
+- `VLLM_PLE_CPU_OFFLOAD=1` keeps the large PLE N-gram table in a dedicated CPU
+  worker so the GPUs retain usable KV cache space.
+- `SYS_PTRACE` allows the PyTorch CUDA IPC registration used by that worker.
+  Without it this environment fails with `pidfd_getfd: Operation not permitted`.
+- `--disable-custom-all-reduce` uses NCCL/PyNCCL. The custom all-reduce kernel
+  fails during CUDA Graph capture on this TP2 SM120 configuration.
+
+The recipe leaves Torch Inductor compilation and FlashInfer autotuning enabled.
+On the validation system, default `torch.compile`, FlashInfer autotune, and
+CUDA Graph capture completed successfully.
+
+## NVFP4 Recipe
+
+The RadixArk NVFP4 checkpoint is hybrid: its outer quantization is ModelOpt
+NVFP4, while the PLE N-gram embedding remains FP8 and includes
+`ngram_embedding.weight_scale`. The preview image chooses the FP8 PLE loader
+only from the outer `Fp8Config`, so it otherwise creates only
+`ngram_embedding.weight` and fails during checkpoint loading.
+
+The recipe builds a tiny derived image that applies
+[qwen38-flash-next-nvfp4-ple-fp8.patch](../patches/qwen38-flash-next-nvfp4-ple-fp8.patch).
+The patch uses `ple_embedding_dtype=float8_e4m3fn` to select the FP8 PLE
+embedding method and register the required scale parameter.
+
+```bash
+docker compose -f compose/qwen38-flash-next-nvfp4-tp2.yml build
+docker compose -f compose/qwen38-flash-next-nvfp4-tp2.yml up -d
+```
+
+This recipe keeps the conservative compilation configuration that was required
+for the tested NVFP4 checkpoint: Inductor compilation is disabled while decode
+CUDA Graphs remain enabled. It also disables FlashInfer autotuning. Those two
+settings are specific to this NVFP4 path; do not copy them into the FP8 recipe
+without reproducing an issue.
+
+## Verify The Server
+
+```bash
+curl -fsS http://127.0.0.1:18005/health
+```
+
+An OpenAI-compatible smoke test is:
+
+```bash
+curl -fsS http://127.0.0.1:18005/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "qwen3.8-flash",
+    "messages": [{"role": "user", "content": "Reply with OK only."}],
+    "temperature": 0,
+    "max_tokens": 32
+  }'
+```
+
+## Operational Notes
+
+- `PYTORCH_ALLOC_CONF=expandable_segments:True` is a low-risk CUDA allocator
+  fragmentation guard. It is not required for an initial boot, but helps avoid
+  failures where aggregate free VRAM exists without a sufficiently large
+  contiguous allocation.
+- The recipes use `max-model-len=262144`, `max-num-seqs=4`, MTP with three
+  speculative tokens, prefix caching, Qwen reasoning parsing, and Qwen Coder
+  tool-call parsing. Lower these limits before assuming a different host has
+  equivalent capacity.
+- The NVFP4 patch is tied to the preview image file layout. Rebuild and review
+  the patch when upstream model support changes.

--- a/patches/qwen38-flash-next-nvfp4-ple-fp8.patch
+++ b/patches/qwen38-flash-next-nvfp4-ple-fp8.patch
@@ -1,0 +1,11 @@
+--- a/vllm/models/qwen3_8_flash_next/nvidia/ple_layer.py
++++ b/vllm/models/qwen3_8_flash_next/nvidia/ple_layer.py
+@@ -187,0 +188 @@
++    config: Qwen3_8FlashNextTextConfig,
+@@ -192,0 +194,3 @@
++    if getattr(config, "ple_embedding_dtype", None) == "float8_e4m3fn":
++        return Qwen3_8FlashNextPLEFp8EmbeddingMethod()
++
+@@ -289 +293 @@
+-                quant_config, f"{prefix}.ngram_embedding"
++                config, quant_config, f"{prefix}.ngram_embedding"

--- a/patches/qwen38-flash-next-nvfp4.Dockerfile
+++ b/patches/qwen38-flash-next-nvfp4.Dockerfile
@@ -1,0 +1,4 @@
+FROM vllm/vllm-openai:qwen38-flash-next
+
+COPY patches/qwen38-flash-next-nvfp4-ple-fp8.patch /tmp/ple-fp8.patch
+RUN cd /usr/local/lib/python3.12/dist-packages && patch -p1 < /tmp/ple-fp8.patch


### PR DESCRIPTION
## Summary

- add a vLLM TP2 FP8 recipe for two 96 GiB RTX PRO 6000 Blackwell GPUs
- add an NVFP4 recipe that builds a small derived image with the required hybrid PLE FP8 loader patch
- document the PLE CPU offload, CUDA IPC capability, and SM120 custom all-reduce workarounds

## Validation

- `docker compose ... config --no-interpolate --quiet` passes for both recipes
- the NVFP4 patch applies cleanly to the validated `vllm/vllm-openai:qwen38-flash-next` image source and its Docker build `RUN patch` step completed successfully
- both configurations previously completed server boot and an OpenAI-compatible API smoke test on the target TP2 hardware

This contribution intentionally makes no throughput claim. The FP8 recipe keeps default compilation and FlashInfer autotuning enabled; the conservative compilation settings are limited to the NVFP4 path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for serving Qwen3.8-Flash-Next with FP8 and NVFP4 vLLM recipes across two GPUs.
  * Added configurations for tensor parallelism, speculative decoding, prefix caching, reasoning, and tool calling.
  * Added a dedicated runbook with setup, launch, health-check, and chat-completion instructions.
  * Added model documentation links to the project index and README.

* **Bug Fixes**
  * Added NVFP4 compatibility for FP8 prefix language embeddings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->