### PR TITLE
Document PCIe link speed flapping on c-payne switches

### DIFF
--- a/INDEX.md
+++ b/INDEX.md
@@ -13,7 +13,7 @@ python3 scripts/generate-wiki-index.py > INDEX.md
 ## Landing Pages And Hubs
 
 - [Glossary And Acronym Guide](GLOSSARY.md) - `GLOSSARY.md`
-- [RTX PRO 6000 Blackwell Wiki Index](INDEX.md) - `INDEX.md`
+- [INDEX](INDEX.md) - `INDEX.md`
 - [RTX PRO 6000 Blackwell LLM Wiki](README.md) - `README.md`
 
 ## Contributor And Onboarding Guides
@@ -37,7 +37,9 @@ python3 scripts/generate-wiki-index.py > INDEX.md
 - [DeepSeek-V4-Flash-0731 on Infernal Invocation r15](models/ds4dspark-infernal-invocation-r15.md) - `models/ds4dspark-infernal-invocation-r15.md`
 - [DeepSeek-V4-Flash-0731 on Infernal Invocation r16](models/ds4dspark-infernal-invocation-r16.md) - `models/ds4dspark-infernal-invocation-r16.md`
 - [DeepSeek-V4-Flash-0731 on Infernal Invocation r18](models/ds4dspark-infernal-invocation-r18.md) - `models/ds4dspark-infernal-invocation-r18.md`
+- [DeepSeek-V4-Flash-0731 Infernal Invocation r19 Preview](models/ds4dspark-infernal-invocation-r19.md) - `models/ds4dspark-infernal-invocation-r19.md`
 - [DeepSeek-V4-Flash-0731 Infernal Invocation r2](models/ds4dspark-infernal-invocation-r2.md) - `models/ds4dspark-infernal-invocation-r2.md`
+- [DeepSeek-V4-Flash-0731 Infernal Invocation r21](models/ds4dspark-infernal-invocation-r21.md) - `models/ds4dspark-infernal-invocation-r21.md`
 - [DeepSeek-V4-Flash-0731 Infernal Invocation r4](models/ds4dspark-infernal-invocation-r4.md) - `models/ds4dspark-infernal-invocation-r4.md`
 - [DeepSeek-V4-Flash-0731 Infernal Invocation r7](models/ds4dspark-infernal-invocation-r7.md) - `models/ds4dspark-infernal-invocation-r7.md`
 - [DeepSeek-V4-Flash-0731 Infernal Invocation r9](models/ds4dspark-infernal-invocation-r9.md) - `models/ds4dspark-infernal-invocation-r9.md`
@@ -52,6 +54,7 @@ python3 scripts/generate-wiki-index.py > INDEX.md
 - [DeepSeek-V4-Flash-DSpark v7](models/ds4dspark-v7.md) - `models/ds4dspark-v7.md`
 - [DeepSeek-V4-Flash and DSpark v8](models/ds4dspark-v8.md) - `models/ds4dspark-v8.md`
 - [DeepSeek-V4-Flash and DSpark v9](models/ds4dspark-v9.md) - `models/ds4dspark-v9.md`
+- [DeepSeek-V4-Flash B12X PCIe Transport Calibration](models/ds4f-b12x-pcie-autotune.md) - `models/ds4f-b12x-pcie-autotune.md`
 - [DeepSeek-V4-Flash: empty `content` from an unclosed `<think>` block](models/ds4f-empty-think/README.md) - `models/ds4f-empty-think/README.md`
 - [Eldritch Enlightenment vLLM Docker](models/eldritch-enlightenment-docker.md) - `models/eldritch-enlightenment-docker.md`
 - [GLM-5.1 MXFP4 Hybrid Native Checkpoint](models/glm-5.1-mxfp4.md) - `models/glm-5.1-mxfp4.md`
@@ -204,6 +207,7 @@ python3 scripts/generate-wiki-index.py > INDEX.md
 - [ASUS ESC8000A-E13P — PEX890xx Bug Report](troubleshooting/asus-esc8000a-e13p-pex890xx-bug-report.md) - `troubleshooting/asus-esc8000a-e13p-pex890xx-bug-report.md`
 - [Troubleshooting -- Common Issues on RTX 6000 Pro Blackwell](troubleshooting/common-issues.md) - `troubleshooting/common-issues.md`
 - [Intermittent GPU Bus Drops on Multi-PSU Open-Air Frames](troubleshooting/gpu-bus-drops-multi-psu-grounding.md) - `troubleshooting/gpu-bus-drops-multi-psu-grounding.md`
+- [PCIe Link Speed Flapping Behind c-payne Switches — Locking Gen5 Without Trapping a Card](troubleshooting/pcie-link-speed-flapping-cpayne.md) - `troubleshooting/pcie-link-speed-flapping-cpayne.md`
 
 ## Daily Summaries
 
@@ -393,6 +397,14 @@ python3 scripts/generate-wiki-index.py > INDEX.md
 - [Daily Summary — 2026-08-18](daily-summaries/2026-08/2026-08-19.md) - `daily-summaries/2026-08/2026-08-19.md`
 - [Daily Summary — 2026-08-19](daily-summaries/2026-08/2026-08-20.md) - `daily-summaries/2026-08/2026-08-20.md`
 - [Daily Summary — 2026-08-20](daily-summaries/2026-08/2026-08-21.md) - `daily-summaries/2026-08/2026-08-21.md`
+- [Daily Summary — 2026-08-21](daily-summaries/2026-08/2026-08-22.md) - `daily-summaries/2026-08/2026-08-22.md`
+- [Daily Summary — 2026-08-22](daily-summaries/2026-08/2026-08-23.md) - `daily-summaries/2026-08/2026-08-23.md`
+- [Daily Summary — 2026-08-23](daily-summaries/2026-08/2026-08-24.md) - `daily-summaries/2026-08/2026-08-24.md`
+- [Daily Summary — 2026-08-24](daily-summaries/2026-08/2026-08-25.md) - `daily-summaries/2026-08/2026-08-25.md`
+- [Daily Summary — 2026-08-25](daily-summaries/2026-08/2026-08-26.md) - `daily-summaries/2026-08/2026-08-26.md`
+- [Daily Summary — 2026-08-26](daily-summaries/2026-08/2026-08-27.md) - `daily-summaries/2026-08/2026-08-27.md`
+- [Daily Summary — 2026-08-27](daily-summaries/2026-08/2026-08-28.md) - `daily-summaries/2026-08/2026-08-28.md`
+- [Daily Summary — 2026-08-28](daily-summaries/2026-08/2026-08-29.md) - `daily-summaries/2026-08/2026-08-29.md`
 - [Daily Summaries](daily-summaries/README.md) - `daily-summaries/README.md`
 
 ## Other Documents

--- a/scripts/pcie-link-supervisor.py
+++ b/scripts/pcie-link-supervisor.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Hold GPU PCIe links at their maximum speed, never locking one below it.
+
+Why this exists
+---------------
+RTX PRO 6000 Blackwell cards renegotiate their PCI Express link speed constantly
+when idle. Behind a c-payne Microchip Switchtec switch that means thousands of
+link down/up cycles per hour on a cabled Gen5 fabric: 1415 transitions across 35
+devices in a two-minute window were measured on the reference system, cycling
+32 -> 5 -> 2.5 -> 32 GT/s.
+
+Setting "Hardware Autonomous Speed Disable" stops that completely. The obvious
+place to set it is a udev rule at device enumeration -- and that is a trap. The
+bit blocks movement in *both* directions, and a udev rule cannot check what
+speed the link actually reached. On the reference system such a rule left one
+GPU at Gen2 x16 for three and a half hours of production training, roughly
+8 GB/s instead of 64 GB/s, with nothing logging an error.
+
+The invariant this script holds
+-------------------------------
+    A link may be locked only after it has been verified at its maximum.
+    Nothing else is ever locked.
+
+Per pass, for every GPU:
+  1) at maximum            -> lock it (if not already locked)
+  2) below maximum         -> UNLOCK and let it climb back
+     a) returns within RECOVER_WAIT       -> lock
+     b) still low and the card is idle    -> force a retrain, then lock
+     c) still low and the card is busy    -> leave UNLOCKED and warn
+        (running at Gen2 is worse than flapping, but a forced retrain under
+         load is worse still, so the repair waits for the card to go idle)
+
+Running periodically means a trapped link is repaired within one interval
+instead of indefinitely.
+
+See troubleshooting/pcie-link-speed-flapping-cpayne.md for the full write-up.
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import time
+
+LOG = "[pcie-link-sup]"
+SYS = "/sys/bus/pci/devices"
+
+NVIDIA_VENDOR = "10de:"
+
+# PCI Express capability register offsets, as setpci names.
+LNKCTL = "CAP_EXP+10.w"      # bit 9 = Hardware Autonomous Width Disable
+LNKCTL2 = "CAP_EXP+30.w"     # bit 5 = Hardware Autonomous Speed Disable, bits 3:0 = target
+SPEED_DIS = 0x0020
+WIDTH_DIS = 0x0200
+RETRAIN = 0x0020             # bit 5 of LNKCTL, self-clearing
+TARGET_MASK = 0x003F
+TARGET_GEN5 = 0x0005
+
+RECOVER_WAIT = 20.0          # seconds to wait for an unlocked link to climb back
+BUSY_UTIL_PCT = 20           # above this the card counts as in use
+GEN_OF = {2.5: 1, 5.0: 2, 8.0: 3, 16.0: 4, 32.0: 5, 64.0: 6}
+
+
+def sh(cmd):
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
+        return r.stdout.strip() if r.returncode == 0 else None
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
+def read(slot, name):
+    try:
+        with open(os.path.join(SYS, slot, name)) as fh:
+            return fh.read().strip()
+    except OSError:
+        return ""
+
+
+def speed(txt):
+    m = re.match(r"([\d.]+)", txt or "")
+    return float(m.group(1)) if m else 0.0
+
+
+def gen(value):
+    return GEN_OF.get(value, "?")
+
+
+def gpus():
+    """[(gpu_slot, parent_downstream_port_slot), ...] for every NVIDIA function 0."""
+    out = sh(["lspci", "-Dn"]) or ""
+    res = []
+    for line in out.splitlines():
+        if NVIDIA_VENDOR not in line:
+            continue
+        slot = line.split()[0]
+        if not slot.endswith(".0"):
+            continue
+        real = os.path.realpath(os.path.join(SYS, slot))
+        res.append((slot, os.path.basename(os.path.dirname(real))))
+    return res
+
+
+def link(slot):
+    return (speed(read(slot, "current_link_speed")), int(read(slot, "current_link_width") or 0),
+            speed(read(slot, "max_link_speed")), int(read(slot, "max_link_width") or 0))
+
+
+def effective_max(slot, parent):
+    """The lower capability of the two ends of the link.
+
+    max_link_width on an endpoint reports what the *card* can do, not how many
+    lanes are physically wired. Without taking the minimum, every x16 card in an
+    x4 slot looks permanently degraded and the repair loop chases it forever.
+    """
+    _, _, own_s, own_w = link(slot)
+    _, _, par_s, par_w = link(parent)
+    eff_s = min(own_s, par_s) if own_s and par_s else (own_s or par_s)
+    eff_w = min(own_w, par_w) if own_w and par_w else (own_w or par_w)
+    return eff_s, eff_w
+
+
+def busy(slot):
+    bus = slot.split(":", 1)[1].upper()
+    out = sh(["nvidia-smi", "--query-gpu=pci.bus_id,utilization.gpu",
+              "--format=csv,noheader,nounits"]) or ""
+    for line in out.splitlines():
+        f = [x.strip() for x in line.split(",")]
+        if len(f) == 2 and f[0].upper().endswith(bus):
+            try:
+                return int(f[1]) > BUSY_UTIL_PCT
+            except ValueError:
+                return False
+    return False
+
+
+def setpci(slot, reg, value, mask):
+    sh(["setpci", "-s", slot, f"{reg}={value:04x}:{mask:04x}"])
+
+
+def get_reg(slot, reg):
+    v = sh(["setpci", "-s", slot, reg])
+    try:
+        return int(v, 16)
+    except (TypeError, ValueError):
+        return None
+
+
+def is_locked(slot):
+    v = get_reg(slot, LNKCTL2)
+    return bool(v is not None and v & SPEED_DIS)
+
+
+def lock(slot, parent, dry):
+    if dry:
+        return "dry-run"
+    for d in (slot, parent):
+        setpci(d, LNKCTL2, SPEED_DIS, SPEED_DIS)
+        setpci(d, LNKCTL, WIDTH_DIS, WIDTH_DIS)
+    return "locked"
+
+
+def unlock(slot, parent, dry):
+    if dry:
+        return "dry-run"
+    for d in (slot, parent):
+        setpci(d, LNKCTL2, TARGET_GEN5, TARGET_MASK)
+        setpci(d, LNKCTL, 0x0000, WIDTH_DIS)
+    return "unlocked"
+
+
+def retrain(parent, dry):
+    if not dry:
+        setpci(parent, LNKCTL, RETRAIN, RETRAIN)
+
+
+def pass_once(dry, verbose):
+    acted = 0
+    for slot, parent in gpus():
+        cur_s, cur_w = link(slot)[:2]
+        max_s, max_w = effective_max(slot, parent)
+        if not cur_s or not max_s:
+            continue
+        at_max = cur_s >= max_s - 0.01 and (not max_w or cur_w >= max_w)
+        locked = is_locked(slot)
+
+        if at_max:
+            if not locked:
+                acted += 1
+                print(f"{LOG} {slot} gen{gen(cur_s)} x{cur_w} at maximum "
+                      f"-> {lock(slot, parent, dry)}", flush=True)
+            elif verbose:
+                print(f"{LOG} {slot} gen{gen(cur_s)} x{cur_w} OK, locked", flush=True)
+            continue
+
+        print(f"{LOG} {slot} BELOW MAXIMUM: gen{gen(cur_s)} x{cur_w} "
+              f"(link supports gen{gen(max_s)} x{max_w}), locked={locked} -> unlocking",
+              flush=True)
+        unlock(slot, parent, dry)
+        acted += 1
+        if dry:
+            print(f"{LOG} {slot} dry-run: would wait for recovery, then lock", flush=True)
+            continue
+
+        deadline = time.time() + RECOVER_WAIT
+        while time.time() < deadline:
+            time.sleep(2)
+            cur_s, cur_w = link(slot)[:2]
+            if cur_s >= max_s - 0.01 and (not max_w or cur_w >= max_w):
+                print(f"{LOG} {slot} recovered on its own to gen{gen(cur_s)} x{cur_w}"
+                      f" -> {lock(slot, parent, dry)}", flush=True)
+                break
+        else:
+            if busy(slot):
+                print(f"{LOG} {slot} still below maximum and the card is BUSY - leaving "
+                      f"UNLOCKED. No forced retrain under load; will retry next pass.",
+                      flush=True)
+            else:
+                print(f"{LOG} {slot} idle, forcing retrain of port {parent}", flush=True)
+                retrain(parent, dry)
+                time.sleep(3)
+                cur_s, cur_w = link(slot)[:2]
+                if cur_s >= max_s - 0.01:
+                    print(f"{LOG} {slot} after retrain gen{gen(cur_s)} x{cur_w}"
+                          f" -> {lock(slot, parent, dry)}", flush=True)
+                else:
+                    print(f"{LOG} {slot} retrain did not help (gen{gen(cur_s)}), "
+                          f"leaving UNLOCKED", flush=True)
+    return acted
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--interval", type=float, default=60.0,
+                    help="seconds between passes; 0 runs a single pass and exits")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="report what would change, touch nothing")
+    ap.add_argument("--verbose", action="store_true",
+                    help="also report links that are already correct")
+    args = ap.parse_args()
+
+    if os.geteuid() != 0 and not args.dry_run:
+        sys.exit(f"{LOG} needs root for setpci")
+
+    print(f"{LOG} start interval={args.interval}s dry_run={args.dry_run} "
+          f"invariant: only ever lock a link verified at its maximum", flush=True)
+    while True:
+        try:
+            pass_once(args.dry_run, args.verbose)
+        except Exception as exc:                            # noqa: BLE001
+            print(f"{LOG} error during pass: {exc}", flush=True)
+        if args.interval <= 0:
+            return
+        time.sleep(args.interval)
+
+
+if __name__ == "__main__":
+    main()

--- a/troubleshooting/common-issues.md
+++ b/troubleshooting/common-issues.md
@@ -35,6 +35,7 @@
 - [PCIe and Stability Issues](#pcie-and-stability-issues)
   - [Intermittent GPU Bus Drops on Multi-PSU Frames](#intermittent-gpu-bus-drops-on-multi-psu-frames)
   - [Surprise Link Down (PCIe ASPM)](#surprise-link-down)
+  - [PCIe Link Speed Flapping (c-payne switches)](#pcie-link-speed-flapping)
   - [NCCL P2P Lockups (IOMMU/UVM)](#nccl-p2p-lockups)
   - [ZFS System Freezes](#zfs-system-freezes)
 - [Miscellaneous](#miscellaneous)
@@ -466,6 +467,29 @@ GRUB_CMDLINE_LINUX_DEFAULT="pcie_aspm=off pcie_port_pm=off"
 - `pcie_port_pm=off` disables PCIe port runtime power management (CRITICAL)
 
 Run `update-grub` and reboot.
+
+---
+
+### PCIe Link Speed Flapping
+
+**Symptom**: No error at all. GPU links renegotiate continuously between Gen1,
+Gen2 and Gen5 — 1415 transitions across 35 devices in two minutes were measured
+on a 17-GPU c-payne system at idle. A single `nvidia-smi` or `lspci` snapshot
+catches one phase of the cycle and looks healthy.
+
+**Check**: Sample once per second, not once.
+```bash
+watch -n1 'cat /sys/bus/pci/devices/0000:e3:00.0/current_link_speed'
+```
+
+**Fix**: Set Hardware Autonomous Speed Disable (Link Control 2, bit 5) on both
+ends of each link — but **only after verifying the link is at its maximum**. The
+bit blocks movement in both directions, so locking a card that happens to be at
+Gen2 traps it there permanently. A udev rule at enumeration cannot make that
+check and has left a production card at Gen2 x16 for hours.
+
+See [PCIe Link Speed Flapping Behind c-payne Switches](pcie-link-speed-flapping-cpayne.md)
+for the register map, the verify-then-lock supervisor, and the ×4-slot pitfall.
 
 ---
 

--- a/troubleshooting/pcie-link-speed-flapping-cpayne.md
+++ b/troubleshooting/pcie-link-speed-flapping-cpayne.md
@@ -1,0 +1,313 @@
+# PCIe Link Speed Flapping Behind c-payne Switches — Locking Gen5 Without Trapping a Card
+
+RTX PRO 6000 Blackwell cards renegotiate their PCI Express (PCIe) link speed
+constantly when idle or lightly loaded. Behind a c-payne Microchip Switchtec
+switch this is not merely cosmetic: every renegotiation is a link down/up cycle
+on a cabled fabric, and cabled Gen5 fabrics are where marginal signalling shows
+up first.
+
+This page documents how to stop the flapping by setting the two PCI Express
+capability bits that disable autonomous link changes, and — more importantly —
+how to do it **without** locking a card at a speed below its maximum. Getting
+that ordering wrong silently costs a working card three quarters of its
+bandwidth.
+
+Measured on the ASRockRack GENOAD24QM32-2L2T/BCM platform described in
+[`hardware/asrockrack-turin-cpayne-16gpu.md`](../hardware/asrockrack-turin-cpayne-16gpu.md).
+
+Related pages:
+
+- [`hardware/asrockrack-turin-cpayne-16gpu.md`](../hardware/asrockrack-turin-cpayne-16gpu.md) — the same board and switch fabric, peer-to-peer bandwidth characterisation.
+- [`hardware/pcie-bandwidth.md`](../hardware/pcie-bandwidth.md) — what a healthy link should deliver.
+- [`troubleshooting/gpu-bus-drops-multi-psu-grounding.md`](gpu-bus-drops-multi-psu-grounding.md) — a different failure mode on the same class of frame; worth ruling out first if cards disappear entirely.
+
+## Table of Contents
+
+- [System Under Test](#system-under-test)
+- [Symptoms](#symptoms)
+- [What The Lock Actually Is](#what-the-lock-actually-is)
+- [The Trap: Locking At Enumeration](#the-trap-locking-at-enumeration)
+- [The Fix: Verify, Then Lock](#the-fix-verify-then-lock)
+- [Manual Procedure](#manual-procedure)
+- [Verification](#verification)
+- [Pitfalls](#pitfalls)
+- [Script](#script)
+
+## System Under Test
+
+| Component | Configuration |
+|---|---|
+| Motherboard | ASRockRack GENOAD24QM32-2L2T/BCM (single-socket SP5) |
+| CPU | AMD EPYC, 8 PCIe root complexes (bus `00`, `20`, `40`, `60`, `80`, `a0`, `c0`, `e0`) |
+| GPUs | 17× NVIDIA RTX PRO 6000 Blackwell Workstation, 96 GB |
+| PCIe fabric | 8× c-payne Microchip Switchtec Gen5 switch boards, PCI ID `1f18:0101` |
+| Uplink | 1× Gen5 ×16 per switch board over MCIO cabling, with retimers |
+| Operating system | Ubuntu 24.04, kernel 7.0.0 |
+
+Each switch board carries two GPUs; four of the eight boards carry a third
+device (an NVMe drive or a network adapter) on a Gen4/Gen5 ×4 downstream port.
+
+## Symptoms
+
+The flapping itself does not raise an error. It is visible only if you sample
+`current_link_speed` faster than the cards change it:
+
+| Observation | Value |
+|---|---|
+| Link transitions across 35 devices, 2-minute window, cards idle | **1415** |
+| Transition pattern | 32 GT/s → 5 GT/s → 2.5 GT/s → 32 GT/s, repeating |
+| Devices involved | Every GPU and its parent downstream switch port |
+| Transitions in the same window after the lock was applied | **0** |
+
+Sampling `/sys/bus/pci/devices/*/current_link_speed` once per second is enough
+to see it. A single `nvidia-smi` or `lspci` snapshot is not — it catches one
+phase of the cycle and looks normal, which is exactly how this gets missed.
+
+Why it matters on this fabric:
+
+- Correctable Physical Layer receiver errors (`RxErr`) accumulate on the switch
+  downstream ports, because every renegotiation retrains the link.
+- The Gen1↔Gen5 retrain is the documented trigger for Surprise Link Down on
+  these systems. See
+  [Surprise Link Down](common-issues.md#surprise-link-down): the root port can
+  suspend *during* a retrain, which surfaces as
+  `aer_uncor_status: 0x00000020` and a system lockup.
+
+That entry prescribes the two kernel parameters that stop the root port from
+suspending. This page is the complementary half — stopping the retrain from
+happening in the first place. Apply both:
+
+```bash
+# /etc/default/grub — from the Surprise Link Down entry
+GRUB_CMDLINE_LINUX_DEFAULT="pcie_aspm=off pcie_port_pm=off"
+```
+
+```bash
+# /etc/modprobe.d/nvidia.conf — stop the driver re-enabling runtime D3
+options nvidia NVreg_DynamicPowerManagement=0x00
+```
+
+One caution on attribution: on the reference system, Surprise Link Down events
+were also produced by a genuine power-delivery fault unrelated to link
+training. Stopping the flapping is worth doing regardless — a Gen5 link that
+renegotiates thousands of times an hour has no business doing so under
+production load — but do not assume it is the only cause of a link-down event
+you are chasing.
+
+## What The Lock Actually Is
+
+There is no lock feature. It is **two bits in two registers of the PCI Express
+capability**, and they must be set on **both ends** of every link.
+
+| Register | `setpci` name | Bit | Meaning |
+|---|---|---|---|
+| Link Control 2 | `CAP_EXP+30.w` | 5 | Hardware Autonomous Speed Disable — this is the lock |
+| Link Control 2 | `CAP_EXP+30.w` | 3:0 | Target Link Speed; `5` = Gen5 |
+| Link Control | `CAP_EXP+10.w` | 9 | Hardware Autonomous Width Disable |
+| Link Control | `CAP_EXP+10.w` | 5 | Retrain Link — a self-clearing write-only trigger |
+| Link Control | `CAP_EXP+10.w` | 1:0 | Active State Power Management (ASPM); keep at `00` |
+
+Reading the two registers on a locked card:
+
+```console
+$ setpci -s e3:00.0 CAP_EXP+30.w
+0025                       # bit 5 set, target speed 5 (Gen5)
+$ setpci -s e3:00.0 CAP_EXP+10.w
+0240                       # bit 9 set, ASPM off
+```
+
+| `CAP_EXP+30.w` | State |
+|---|---|
+| `0025` | Locked, target Gen5 |
+| `0005` | Unlocked, target Gen5 |
+
+Both ends means the GPU **and** its parent downstream port on the switch.
+Setting only one end produces a half-applied lock and confusing behaviour:
+
+```console
+$ basename $(dirname $(realpath /sys/bus/pci/devices/0000:e3:00.0))
+0000:e2:00.0
+```
+
+## The Trap: Locking At Enumeration
+
+The obvious implementation is a udev rule that sets the bits when the device
+appears, before the NVIDIA driver binds, while the link is freshly trained:
+
+```udev
+# DO NOT USE — see below
+ACTION=="add", SUBSYSTEM=="pci", KERNEL=="*:*:*.0", ATTR{vendor}=="0x10de", DRIVER=="", \
+    RUN+="/usr/bin/setpci -s %k CAP_EXP+30.w=0x0025:0x003f", \
+    RUN+="/usr/bin/setpci -s %k CAP_EXP+10.w=0x0200:0x0203"
+```
+
+This does stop the flapping. It also has no way to check what speed the link
+actually reached, and **Hardware Autonomous Speed Disable blocks movement in
+both directions**. A card that is not at Gen5 at that instant can never climb
+back.
+
+> [!WARNING]
+> On this system that rule left GPU `e3:00.0` at **Gen2 ×16 for three and a half
+> hours of production training** — roughly 8 GB/s instead of 64 GB/s — while
+> every other card sat at Gen5. Nothing logged an error. The card reported 100 %
+> utilisation the whole time. It was found only by walking every link's
+> negotiated speed and comparing it against what the link was capable of.
+
+A udev rule fires once, at a moment you do not control, with no feedback loop.
+That is the wrong shape for this problem.
+
+## The Fix: Verify, Then Lock
+
+Move the lock into a small supervisor that runs periodically and holds one
+invariant:
+
+> A link may be locked only after it has been verified at its maximum. Nothing
+> else is ever locked.
+
+Per pass, for each GPU:
+
+| Link state | Action |
+|---|---|
+| At its maximum | Lock it, if not already locked. |
+| Below maximum | **Unlock** it and allow 20 s to climb back on its own. |
+| …came back up | Lock it. |
+| …still low, card idle | Force a retrain on the parent port, then lock. |
+| …still low, card busy | Leave it **unlocked**, log a warning, retry next pass. |
+
+The last row matters. A card running at Gen2 is worse than a card that flaps, so
+a degraded link is never left locked — but a forced retrain under load is worse
+still, so the repair waits for the card to go idle.
+
+With a 60-second interval, the worst case after a boot is one link below its
+maximum for a minute, instead of indefinitely.
+
+A first pass on a healthy system, with one idle card that had dropped to Gen1:
+
+```console
+$ systemctl status pcie-link-supervisor
+[pcie-link-sup] 0000:03:00.0 gen5 x16 at maximum -> locked
+[pcie-link-sup] 0000:04:00.0 gen5 x16 at maximum -> locked
+...
+[pcie-link-sup] 0000:c5:00.0 gen5 x4 at maximum -> locked
+[pcie-link-sup] 0000:e3:00.0 gen5 x16 at maximum -> locked
+[pcie-link-sup] 0000:e4:00.0 BELOW MAXIMUM: gen1 x16 (link supports gen5 x16), locked=False -> unlocking
+[pcie-link-sup] 0000:e4:00.0 idle, forcing retrain of port 0000:e2:01.0
+[pcie-link-sup] 0000:e4:00.0 after retrain gen5 x16 -> locked
+```
+
+## Manual Procedure
+
+> [!WARNING]
+> Stop the supervisor first. It re-checks every 60 seconds and will undo manual
+> changes: `systemctl stop pcie-link-supervisor`.
+
+`setpci` takes `value:mask`, so only the masked bits are touched.
+
+```bash
+GPU=e3:00.0
+PORT=$(basename $(dirname $(realpath /sys/bus/pci/devices/0000:$GPU)) | sed 's/0000://')
+
+# 1. Unlock: target speed Gen5 (bits 3:0 = 5), clear Hardware Autonomous Speed Disable (bit 5)
+setpci -s $GPU  CAP_EXP+30.w=0x0005:0x003f
+setpci -s $PORT CAP_EXP+30.w=0x0005:0x003f
+setpci -s $GPU  CAP_EXP+10.w=0x0000:0x0200     # clear Hardware Autonomous Width Disable
+setpci -s $PORT CAP_EXP+10.w=0x0000:0x0200
+
+# 2. A loaded card usually returns to Gen5 within seconds on its own.
+#    An idle card needs a directed retrain. The Retrain Link bit goes on the
+#    PORT, not the GPU, and clears itself.
+setpci -s $PORT CAP_EXP+10.w=0x0020:0x0020
+sleep 3
+cat /sys/bus/pci/devices/0000:$GPU/current_link_speed
+
+# 3. Only once the speed is confirmed, lock.
+setpci -s $GPU  CAP_EXP+30.w=0x0020:0x0020
+setpci -s $PORT CAP_EXP+30.w=0x0020:0x0020
+setpci -s $GPU  CAP_EXP+10.w=0x0200:0x0200
+setpci -s $PORT CAP_EXP+10.w=0x0200:0x0200
+
+systemctl start pcie-link-supervisor
+```
+
+## Verification
+
+```bash
+# every card's negotiated speed and width
+nvidia-smi --query-gpu=index,pci.bus_id,pcie.link.gen.current,pcie.link.width.current \
+           --format=csv,noheader
+
+# is the lock bit set?
+for g in $(lspci -Dn | grep 10de: | awk '{print $1}' | grep '\.0$'); do
+    printf '%s LnkCtl2=%s LnkCtl=%s\n' "${g#0000:}" \
+        "$(setpci -s ${g#0000:} CAP_EXP+30.w)" "$(setpci -s ${g#0000:} CAP_EXP+10.w)"
+done
+
+# watch for flapping: sample once per second and look for changes
+watch -n1 'cat /sys/bus/pci/devices/0000:e3:00.0/current_link_speed'
+```
+
+Speed field encoding, for reading `CAP_EXP+30.w` by hand:
+
+| Bits 3:0 | GT/s | Name | ×16 bandwidth |
+|---|---|---|---|
+| `1` | 2.5 | Gen1 | ~4 GB/s |
+| `2` | 5.0 | Gen2 | ~8 GB/s |
+| `3` | 8.0 | Gen3 | ~16 GB/s |
+| `4` | 16.0 | Gen4 | ~32 GB/s |
+| `5` | 32.0 | Gen5 | ~64 GB/s |
+
+## Pitfalls
+
+**A narrow link is not always a fault.** `max_link_width` on an endpoint reports
+what the *card* is capable of, not how many lanes are physically wired. On this
+board GPU `c5:00.0` reports ×16 but sits on a ×4 downstream port, so **Gen5 ×4
+is its maximum and it is healthy**. Always compare the negotiated width against
+`min(endpoint maximum, port maximum)`. Comparing against the card's own maximum
+makes four devices look permanently degraded and sends any repair loop chasing
+them forever.
+
+**An idle Blackwell card at Gen1 is normal.** It is power management, not a
+fault. It matters only if something then locks it there.
+
+**Nothing survives a reboot.** PCI configuration space resets on every power
+cycle, so the lock must be reapplied by a service or a udev rule each boot. That
+is precisely why the naive udev rule is tempting — and why it must not be used.
+
+**Check both ends when debugging.** If a link behaves oddly, read the registers
+on the GPU *and* on its parent port. A mismatch between the two is a strong hint
+that something applied the lock to only one side.
+
+## Script
+
+[`scripts/pcie-link-supervisor.py`](../scripts/pcie-link-supervisor.py) implements
+the verify-then-lock loop described above. It has no dependencies beyond
+`python3`, `lspci`, `setpci` and `nvidia-smi`.
+
+```bash
+# show what it would do, without changing anything
+sudo ./scripts/pcie-link-supervisor.py --interval 0 --dry-run --verbose
+
+# one pass and exit
+sudo ./scripts/pcie-link-supervisor.py --interval 0
+
+# run as a service
+sudo ./scripts/pcie-link-supervisor.py --interval 60
+```
+
+A systemd unit:
+
+```ini
+[Unit]
+Description=Hold GPU PCIe links at Gen5, never locking below maximum
+After=multi-user.target nvidia-persistenced.service
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/pcie-link-supervisor.py --interval 60
+Restart=always
+RestartSec=15
+Nice=10
+
+[Install]
+WantedBy=multi-user.target
+```


### PR DESCRIPTION
## What

RTX PRO 6000 Blackwell cards renegotiate their PCIe link speed continuously when idle. On a 17-GPU ASRockRack GENOAD24QM32 + 8× c-payne Microchip Switchtec system this measured **1415 link transitions across 35 devices in a two-minute window**, cycling 32 → 5 → 2.5 → 32 GT/s. A single `nvidia-smi` or `lspci` snapshot catches one phase of the cycle and looks perfectly healthy, which is how it goes unnoticed.

This connects to the existing [Surprise Link Down](troubleshooting/common-issues.md#surprise-link-down) entry: that already documents the Gen1↔Gen5 retrain as the trigger for `aer_uncor_status: 0x00000020`. That entry covers stopping the root port from suspending; this page covers stopping the retrain from happening at all. They are complementary.

## The part worth reviewing

Setting Hardware Autonomous Speed Disable (Link Control 2, bit 5) stops the flapping completely — verified, 1415 → 0 transitions. But **the bit blocks link speed movement in both directions**, and a udev rule at enumeration has no way to check what speed the link actually reached.

On the reference system that mistake left GPU `e3:00.0` at **Gen2 ×16 for three and a half hours of production training** — roughly 8 GB/s instead of 64 GB/s — with nothing logging an error and the card reporting 100 % utilisation throughout.

So `scripts/pcie-link-supervisor.py` holds one invariant instead:

> A link may be locked only after it has been verified at its maximum. Nothing else is ever locked.

A degraded link is unlocked and repaired rather than left trapped, and a forced retrain is never done on a card that is under load.

## Also handles

`max_link_width` on an endpoint reports the **card's** capability, not the lanes physically wired. On this board one GPU sits on a ×4 downstream port and reports ×16, so Gen5 ×4 is its correct maximum. Comparing against the card's own maximum instead of `min(both ends)` makes four devices look permanently degraded and sends a repair loop chasing them forever.

## Files

| File | |
|---|---|
| `troubleshooting/pcie-link-speed-flapping-cpayne.md` | New page: register map, the trap, the supervisor, manual procedure, pitfalls |
| `scripts/pcie-link-supervisor.py` | Verify-then-lock loop; stdlib only, plus `lspci`/`setpci`/`nvidia-smi` |
| `troubleshooting/common-issues.md` | New entry under PCIe and Stability Issues, cross-linked from Surprise Link Down |
| `INDEX.md` | Regenerated |

> [!NOTE]
> `INDEX.md` was regenerated with `scripts/generate-wiki-index.py`, so it also picks up eight daily-summary pages added since the last regeneration. Those lines are not part of this change.

Script verified on the reference system: detects all 17 cards, resolves each parent downstream port, and evaluates the ×4 card correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DeWqtWUBu7UPXZn9F3ZoPz


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a supervisor tool to monitor and stabilize NVIDIA GPU PCIe link speeds, with dry-run, verbose, and continuous monitoring options.
  * Added runbook entries for new model runs and B12X PCIe transport calibration.

* **Documentation**
  * Added troubleshooting guidance for PCIe link-speed flapping, including monitoring, verification, and recovery procedures.
  * Expanded daily summaries through 2026-08-28 and updated the wiki index label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->