### PR TITLE
docs(glm53): add qualified cuMem LMCache profile

### DIFF
--- a/compose/glm53-flash-nvfp4-jovian-cumem.yml
+++ b/compose/glm53-flash-nvfp4-jovian-cumem.yml
@@ -1,0 +1,182 @@
+name: glm53-flash-jovian-cumem
+
+services:
+  lmcache:
+    profiles: [cumem]
+    image: ${IMAGE:?set IMAGE to the fleet-qualified local image}
+    container_name: ${NAME:-glm53-flash-jovian-cumem}-lmcache
+    user: "0:0"
+    restart: unless-stopped
+    init: true
+    network_mode: host
+    ipc: host
+    shm_size: 56g
+    security_opt:
+      - label=disable
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["0", "1", "2", "3"]
+              capabilities: [gpu]
+    environment:
+      CUDA_DEVICE_ORDER: PCI_BUS_ID
+      CUDA_VISIBLE_DEVICES: "0,1,2,3"
+      NVIDIA_VISIBLE_DEVICES: "0,1,2,3"
+      LMCACHE_CUMEM_BROKER_DIR: /run/lmcache-cumem
+      LMCACHE_MP_TRANSFER_MODE: lmcache_driven
+    volumes:
+      - lmcache-cumem-broker:/run/lmcache-cumem
+    entrypoint: [/opt/venv/bin/lmcache]
+    command:
+      - server
+      - --host
+      - 127.0.0.1
+      - --port
+      - "5555"
+      - --http-host
+      - 127.0.0.1
+      - --http-port
+      - "8080"
+      - --chunk-size
+      - "8192"
+      - --l1-size-gb
+      - "48"
+      - --eviction-policy
+      - LRU
+      - --supported-transfer-mode
+      - lmcache_driven
+      - --separate-object-groups
+      - --shm-name
+      - glm53_flash_jovian_cumem
+    healthcheck:
+      test:
+        - CMD
+        - /opt/venv/bin/python
+        - -c
+        - >-
+          import json, urllib.request;
+          body=json.load(urllib.request.urlopen("http://127.0.0.1:8080/healthcheck", timeout=2));
+          assert body == {"status": "healthy"}
+      interval: 5s
+      timeout: 3s
+      retries: 24
+      start_period: 20s
+
+  server:
+    profiles: [cumem]
+    image: ${IMAGE:?set IMAGE to the fleet-qualified local image}
+    container_name: ${NAME:-glm53-flash-jovian-cumem}-server
+    user: "0:0"
+    restart: unless-stopped
+    init: true
+    network_mode: host
+    ipc: host
+    shm_size: 32g
+    security_opt:
+      - label=disable
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["0", "1", "2", "3"]
+              capabilities: [gpu]
+    depends_on:
+      lmcache:
+        condition: service_healthy
+    ulimits:
+      memlock: -1
+      stack: 67108864
+      nofile:
+        soft: 1048576
+        hard: 1048576
+    environment:
+      CUDA_DEVICE_ORDER: PCI_BUS_ID
+      CUDA_VISIBLE_DEVICES: "0,1,2,3"
+      NVIDIA_VISIBLE_DEVICES: "0,1,2,3"
+      LMCACHE_CUMEM_BROKER_DIR: /run/lmcache-cumem
+      LMCACHE_MP_TRANSFER_MODE: lmcache_driven
+      PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+      VLLM_WORKER_SHUTDOWN_TIMEOUT_SECONDS: "60"
+    volumes:
+      - lmcache-cumem-broker:/run/lmcache-cumem
+      - ${MODEL_DIR:?set MODEL_DIR to the downloaded checkpoint}:/model:ro
+      - ${CACHE_DIR:?set CACHE_DIR to a writable JIT cache directory}:/cache
+    entrypoint: [/opt/venv/bin/vllm]
+    command:
+      - serve
+      - /model
+      - --served-model-name
+      - glm-5.3-flash
+      - --host
+      - 0.0.0.0
+      - --port
+      - "${PORT:-8001}"
+      - --trust-remote-code
+      - --attention-backend
+      - B12X
+      - --moe-backend
+      - b12x
+      - --linear-backend
+      - b12x
+      - --tensor-parallel-size
+      - "4"
+      - --decode-context-parallel-size
+      - "4"
+      - --distributed-executor-backend
+      - mp
+      - --max-model-len
+      - "1048576"
+      - --max-num-batched-tokens
+      - "8192"
+      - --max-num-seqs
+      - "16"
+      - --block-size
+      - "512"
+      - --kv-cache-memory
+      - "33554432000"
+      - --kv-cache-dtype
+      - fp8
+      - --gpu-memory-utilization
+      - "0.945"
+      - --max-cudagraph-capture-size
+      - "128"
+      - --enable-cumem-allocator
+      - --shutdown-timeout
+      - "60"
+      - --enable-prefix-caching
+      - --enable-prompt-tokens-details
+      - --enable-chunked-prefill
+      - --async-scheduling
+      - --speculative-config
+      - '{"method":"mtp","num_speculative_tokens":3,"moe_backend":"humming","attention_backend":"B12X"}'
+      - --kv-transfer-config
+      - '{"kv_connector":"LMCacheMPConnector","kv_role":"kv_both","kv_connector_extra_config":{"lmcache.mp.host":"tcp://127.0.0.1","lmcache.mp.port":5555,"lmcache.mp.mq_timeout":60,"lmcache.mp.heartbeat_interval":5,"lmcache.mp.mp_transfer_mode":"lmcache_driven"}}'
+      - --reasoning-parser
+      - glm45
+      - --tool-call-parser
+      - glm47
+      - --enable-auto-tool-choice
+      - --default-chat-template-kwargs
+      - '{"reasoning_effort":"high"}'
+    healthcheck:
+      test:
+        - CMD
+        - /opt/venv/bin/python
+        - -c
+        - >-
+          import urllib.request;
+          assert urllib.request.urlopen("http://127.0.0.1:${PORT:-8001}/health", timeout=2).status == 200
+      interval: 10s
+      timeout: 3s
+      retries: 90
+      start_period: 20m
+
+volumes:
+  lmcache-cumem-broker:
+    name: ${BROKER_VOLUME:-glm53-flash-jovian-cumem-broker}
+    labels:
+      local-inference.glm53.owner: root
+      local-inference.glm53.purpose: same-uid-cumem-scm-rights

--- a/models/glm53-flash/README.md
+++ b/models/glm53-flash/README.md
@@ -37,7 +37,7 @@ The runtime contract is:
 ## Image and source recipe
 
 The final qualified image ID is
-`sha256:1d43855573a38e90215b785fb158498bb3654d75c45cef258c512e08c0036ffb`.
+`sha256:67967ddac438bec8393a2822d00c532f1417fc34eb7652c46ec9a2040559a05a`.
 It is a fleet-qualified local artifact, not a published public-registry
 digest. The launcher therefore requires `IMAGE` and rejects any local tag
 that does not resolve to that exact ID. Do not invent or substitute a registry
@@ -46,7 +46,7 @@ location.
 The qualified r10 source recipe consists of:
 
 - LMCache
-  [`c43866fa9aecd18a7c9f49fa791fdad0655506da`](https://github.com/local-inference-lab/LMCache/commit/c43866fa9aecd18a7c9f49fa791fdad0655506da);
+  [`fb167fed58b5f3b4d3e050efcffcea9b5b70f715`](https://github.com/local-inference-lab/LMCache/commit/fb167fed58b5f3b4d3e050efcffcea9b5b70f715);
 - vLLM transfer-mode validator
   [`b39d501b26`](https://github.com/local-inference-lab/vllm/commit/b39d501b26cbc2acd449b00188ee6321aecc407e)
   ([PR #553](https://github.com/local-inference-lab/vllm/pull/553));
@@ -71,7 +71,7 @@ export CACHE_DIR=/path/to/writable-glm53-cache
 Render without starting services:
 
 ```bash
-IMAGE=sha256:1d43855573a38e90215b785fb158498bb3654d75c45cef258c512e08c0036ffb \
+IMAGE=sha256:67967ddac438bec8393a2822d00c532f1417fc34eb7652c46ec9a2040559a05a \
 MODEL_DIR=/path/to/glm-5.3-flash \
 CACHE_DIR=/path/to/writable-glm53-cache \
 ./scripts/run-glm53-flash-jovian-cumem-compose.sh config

--- a/models/glm53-flash/README.md
+++ b/models/glm53-flash/README.md
@@ -1,0 +1,121 @@
+# GLM-5.3-Flash optional Jovian Judgement cuMem sidecar
+
+This directory records the **opt-in** Jovian Judgement r10 cuMem CUDA-IPC
+sidecar profile. It is additive: it does not replace the in-tree community
+runbook at [`../glm-5.3-flash.md`](../glm-5.3-flash.md), and it does not ship
+the default Jovian production Compose, Dockerfiles, or launchers.
+
+The base production-stack proposal (TP4/DCP4 Jovian NVFP4 host and public
+Compose, image pins, and `STACK=jovian` launcher) lives in
+[PR #85](https://github.com/local-inference-lab/rtx6kpro/pull/85). Those files
+are not assumed to exist on this branch. This profile only adds:
+
+- [`compose/glm53-flash-nvfp4-jovian-cumem.yml`](../../compose/glm53-flash-nvfp4-jovian-cumem.yml)
+- [`scripts/run-glm53-flash-jovian-cumem-compose.sh`](../../scripts/run-glm53-flash-jovian-cumem-compose.sh)
+- [`scripts/test-glm53-cumem-contract.sh`](../../scripts/test-glm53-cumem-contract.sh)
+
+The topology is one GPU-enabled LMCache sidecar process mapped across GPUs 0-3
+and one TP4/DCP4 vLLM service. Both run as UID 0 and mount the same root-owned
+named broker volume at `/run/lmcache-cumem`.
+
+The runtime contract is:
+
+- served name `glm-5.3-flash`;
+- TP4, DCP4, exact model length 1,048,576;
+- MTP3, 8,192 maximum batched tokens, 16 maximum sequences;
+- explicit FP8 KV with exactly 33,554,432,000 bytes (31.25 GiB) per GPU;
+- GPU-memory utilization 0.945;
+- CUDA graphs enabled with maximum capture size 128;
+- automatic prefix caching and prompt-token details enabled;
+- LMCache `lmcache_driven`, chunk size 8,192, 48 GiB L1, and separate object
+  groups;
+- manual cuMem allocation scoped by the r10 source change to KV only; model
+  weights remain on the normal allocator;
+- 60-second vLLM and worker shutdown budgets; and
+- `restart: unless-stopped` for both services.
+
+## Image and source recipe
+
+The final qualified image ID is
+`sha256:1d43855573a38e90215b785fb158498bb3654d75c45cef258c512e08c0036ffb`.
+It is a fleet-qualified local artifact, not a published public-registry
+digest. The launcher therefore requires `IMAGE` and rejects any local tag
+that does not resolve to that exact ID. Do not invent or substitute a registry
+location.
+
+The qualified r10 source recipe consists of:
+
+- LMCache
+  [`c43866fa9aecd18a7c9f49fa791fdad0655506da`](https://github.com/local-inference-lab/LMCache/commit/c43866fa9aecd18a7c9f49fa791fdad0655506da);
+- vLLM transfer-mode validator
+  [`b39d501b26`](https://github.com/local-inference-lab/vllm/commit/b39d501b26cbc2acd449b00188ee6321aecc407e)
+  ([PR #553](https://github.com/local-inference-lab/vllm/pull/553));
+- the r10 KV-only cuMem allocator change, whose public PR is still pending;
+- graceful worker shutdown
+  [`88cff3d5a9`](https://github.com/local-inference-lab/vllm/commit/88cff3d5a98b95df9ceeff77aa676ef2f18a03b6)
+  ([PR #554](https://github.com/local-inference-lab/vllm/pull/554)); and
+- the
+  [fleet qualification receipt](https://github.com/Apple-Federal-Credit-Union/fleet-infra/pull/310).
+
+Because the KV-only allocator PR is pending and the final image is not
+published, these pins document provenance but are not presented as a
+standalone public image build. Use the exact qualified local image and the
+public Compose/launcher surface:
+
+```bash
+export IMAGE=<local-tag-resolving-to-the-qualified-image-id>
+export MODEL_DIR=/path/to/glm-5.3-flash
+export CACHE_DIR=/path/to/writable-glm53-cache
+./scripts/run-glm53-flash-jovian-cumem-compose.sh up
+```
+
+Render without starting services:
+
+```bash
+IMAGE=sha256:1d43855573a38e90215b785fb158498bb3654d75c45cef258c512e08c0036ffb \
+MODEL_DIR=/path/to/glm-5.3-flash \
+CACHE_DIR=/path/to/writable-glm53-cache \
+./scripts/run-glm53-flash-jovian-cumem-compose.sh config
+```
+
+## Qualification evidence
+
+| Gate | Qualified result |
+| --- | --- |
+| Native cuMem lifecycle | One sidecar PID on GPUs 0-3; allocation/alias deduplication; bidirectional writes; padding canary; partial rollback; unregister/re-register |
+| Cold 32k | Coherent; 64 objects / 818,151,424 bytes |
+| Automatic unregister | 4 allocations / 184 aliases to 0 / 0; L1 preserved |
+| Warm external reload | Coherent; `cached_tokens=24576` |
+| Isolation | Unrelated sentinel remained coherent |
+| Long context | 524,288 tokens coherent in 84.67 seconds; zero restarts/OOM |
+| 32k prefill | 12,336 tok/s; TTFT 2.702 seconds |
+| C1 decode | 224.135 tok/s |
+| C8 decode | 806.988 tok/s; 305.480 steps/s; acceptance 2.642; queue 0; errors 0 |
+| Source hardening | 160 tests passed |
+| Selected runtime suites | 129/129, then 116/116 in the subsequent pass |
+
+The 32 GiB KV setting is explicitly rejected. A real 524,288-token request
+OOMed during a transient 512 MiB DCP all-gather with approximately 149 MiB
+free. The qualified 31.25 GiB setting completed that request coherently.
+Other rejected configurations are ordinary CUDA IPC (Xid 31), merged
+recurrent object groups (handle corruption), manual cuMem allocation applied
+to model weights (load-time OOM), and a zero shutdown timeout (incomplete
+unregister).
+
+## Stop and rollback
+
+Always stop vLLM before LMCache so automatic unregister can finish:
+
+```bash
+IMAGE=<qualified-local-image> \
+MODEL_DIR=/path/to/glm-5.3-flash \
+CACHE_DIR=/path/to/writable-glm53-cache \
+./scripts/run-glm53-flash-jovian-cumem-compose.sh down
+```
+
+A vLLM-only restart preserves the sidecar's L1; stopping the sidecar discards
+process-local L1. To roll back publicly, stop this cuMem profile and return to
+the production stack proposed in
+[PR #85](https://github.com/local-inference-lab/rtx6kpro/pull/85), or to the
+community Jovian Judgement runbook in [`../glm-5.3-flash.md`](../glm-5.3-flash.md).
+Do not silently approximate an unpublished r10 no-LMCache image.

--- a/models/glm53-flash/README.md
+++ b/models/glm53-flash/README.md
@@ -54,8 +54,7 @@ The qualified r10 source recipe consists of:
 - graceful worker shutdown
   [`88cff3d5a9`](https://github.com/local-inference-lab/vllm/commit/88cff3d5a98b95df9ceeff77aa676ef2f18a03b6)
   ([PR #554](https://github.com/local-inference-lab/vllm/pull/554)); and
-- the
-  [fleet qualification receipt](https://github.com/Apple-Federal-Credit-Union/fleet-infra/pull/310).
+- the runtime qualification evidence recorded in this profile.
 
 Because the KV-only allocator PR is pending and the final image is not
 published, these pins document provenance but are not presented as a

--- a/scripts/run-glm53-flash-jovian-cumem-compose.sh
+++ b/scripts/run-glm53-flash-jovian-cumem-compose.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPOSE_FILE="${COMPOSE_FILE:-${ROOT_DIR}/compose/glm53-flash-nvfp4-jovian-cumem.yml}"
+EXPECTED_IMAGE_ID="sha256:1d43855573a38e90215b785fb158498bb3654d75c45cef258c512e08c0036ffb"
+
+IMAGE="${IMAGE:?set IMAGE to a local tag or ID for the fleet-qualified image}"
+MODEL_DIR="${MODEL_DIR:?set MODEL_DIR to the downloaded GLM-5.3 checkpoint}"
+CACHE_DIR="${CACHE_DIR:?set CACHE_DIR to a writable JIT cache directory}"
+NAME="${NAME:-glm53-flash-jovian-cumem}"
+BROKER_VOLUME="${BROKER_VOLUME:-glm53-flash-jovian-cumem-broker}"
+PORT="${PORT:-8001}"
+ACTION="${1:-up}"
+
+export IMAGE MODEL_DIR CACHE_DIR NAME BROKER_VOLUME PORT
+compose=(docker compose --profile cumem -p "${NAME}" -f "${COMPOSE_FILE}")
+
+die() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 2
+}
+
+verify_image() {
+  local actual_image_id
+  actual_image_id="$(docker image inspect "${IMAGE}" --format '{{.Id}}')" ||
+    die "IMAGE is not present locally: ${IMAGE}"
+  [[ "${actual_image_id}" == "${EXPECTED_IMAGE_ID}" ]] ||
+    die "IMAGE resolves to ${actual_image_id}; expected ${EXPECTED_IMAGE_ID}"
+}
+
+prepare_launch() {
+  [[ -f "${MODEL_DIR}/config.json" ]] ||
+    die "MODEL_DIR does not look like a local Hugging Face checkpoint: ${MODEL_DIR}"
+  mkdir -p "${CACHE_DIR}"
+  verify_image
+
+  docker volume create "${BROKER_VOLUME}" >/dev/null
+  local broker_owner
+  broker_owner="$(
+    docker run --rm \
+      --user 0:0 \
+      --volume "${BROKER_VOLUME}:/run/lmcache-cumem" \
+      --entrypoint stat \
+      "${IMAGE}" \
+      -c '%u:%g' /run/lmcache-cumem
+  )"
+  [[ "${broker_owner}" == "0:0" ]] ||
+    die "${BROKER_VOLUME} must be root-owned; found ${broker_owner}"
+}
+
+start_stack() {
+  prepare_launch
+  "${compose[@]}" up -d lmcache
+  "${compose[@]}" up -d server
+}
+
+stop_stack() {
+  # Preserve graceful automatic unregister: workers stop before the sidecar.
+  "${compose[@]}" stop -t 90 server
+  "${compose[@]}" stop -t 90 lmcache
+}
+
+case "${ACTION}" in
+  up|start)
+    start_stack
+    ;;
+  restart)
+    stop_stack
+    start_stack
+    ;;
+  down|stop)
+    stop_stack
+    "${compose[@]}" down
+    ;;
+  config|ps)
+    "${compose[@]}" "${ACTION}"
+    ;;
+  logs)
+    "${compose[@]}" logs -f --tail=200
+    ;;
+  *)
+    die "usage: $0 [up|restart|down|logs|ps|config]"
+    ;;
+esac
+
+printf '%s\n' \
+  "profile=cumem" \
+  "image=${IMAGE}" \
+  "expected_image_id=${EXPECTED_IMAGE_ID}" \
+  "model_dir=${MODEL_DIR}" \
+  "cache_dir=${CACHE_DIR}" \
+  "broker_volume=${BROKER_VOLUME}" \
+  "served_model_name=glm-5.3-flash" \
+  "port=${PORT}"

--- a/scripts/run-glm53-flash-jovian-cumem-compose.sh
+++ b/scripts/run-glm53-flash-jovian-cumem-compose.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 COMPOSE_FILE="${COMPOSE_FILE:-${ROOT_DIR}/compose/glm53-flash-nvfp4-jovian-cumem.yml}"
-EXPECTED_IMAGE_ID="sha256:1d43855573a38e90215b785fb158498bb3654d75c45cef258c512e08c0036ffb"
+EXPECTED_IMAGE_ID="sha256:67967ddac438bec8393a2822d00c532f1417fc34eb7652c46ec9a2040559a05a"
 
 IMAGE="${IMAGE:?set IMAGE to a local tag or ID for the fleet-qualified image}"
 MODEL_DIR="${MODEL_DIR:?set MODEL_DIR to the downloaded GLM-5.3 checkpoint}"

--- a/scripts/test-glm53-cumem-contract.sh
+++ b/scripts/test-glm53-cumem-contract.sh
@@ -5,7 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 COMPOSE_FILE="${ROOT_DIR}/compose/glm53-flash-nvfp4-jovian-cumem.yml"
 LAUNCHER="${ROOT_DIR}/scripts/run-glm53-flash-jovian-cumem-compose.sh"
 README="${ROOT_DIR}/models/glm53-flash/README.md"
-IMAGE_ID="sha256:1d43855573a38e90215b785fb158498bb3654d75c45cef258c512e08c0036ffb"
+IMAGE_ID="sha256:67967ddac438bec8393a2822d00c532f1417fc34eb7652c46ec9a2040559a05a"
 
 for path in "${COMPOSE_FILE}" "${LAUNCHER}" "${README}"; do
   [[ -f "${path}" ]] || {
@@ -75,7 +75,7 @@ grep -Fq -- "${IMAGE_ID}" "${LAUNCHER}"
 grep -Fq -- '--profile cumem' "${LAUNCHER}"
 grep -Fq -- 'stop -t 90 server' "${LAUNCHER}"
 grep -Fq -- 'stop -t 90 lmcache' "${LAUNCHER}"
-grep -Fq -- 'c43866fa9aecd18a7c9f49fa791fdad0655506da' "${README}"
+grep -Fq -- 'fb167fed58b5f3b4d3e050efcffcea9b5b70f715' "${README}"
 grep -Fq -- 'b39d501b26' "${README}"
 grep -Fq -- '88cff3d5a9' "${README}"
 grep -Fq -- '129/129' "${README}"

--- a/scripts/test-glm53-cumem-contract.sh
+++ b/scripts/test-glm53-cumem-contract.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPOSE_FILE="${ROOT_DIR}/compose/glm53-flash-nvfp4-jovian-cumem.yml"
+LAUNCHER="${ROOT_DIR}/scripts/run-glm53-flash-jovian-cumem-compose.sh"
+README="${ROOT_DIR}/models/glm53-flash/README.md"
+IMAGE_ID="sha256:1d43855573a38e90215b785fb158498bb3654d75c45cef258c512e08c0036ffb"
+
+for path in "${COMPOSE_FILE}" "${LAUNCHER}" "${README}"; do
+  [[ -f "${path}" ]] || {
+    printf 'missing required path: %s\n' "${path}" >&2
+    exit 1
+  }
+done
+
+rendered="$(mktemp)"
+trap 'rm -f "${rendered}"' EXIT
+
+IMAGE="${IMAGE_ID}" \
+MODEL_DIR=/tmp/glm53-model \
+CACHE_DIR=/tmp/glm53-cache \
+docker compose --profile cumem -f "${COMPOSE_FILE}" config >"${rendered}"
+
+require_rendered() {
+  local value=$1
+  grep -Fq -- "${value}" "${rendered}" || {
+    printf 'rendered Compose is missing: %s\n' "${value}" >&2
+    exit 1
+  }
+}
+
+for value in \
+  "${IMAGE_ID}" \
+  'restart: unless-stopped' \
+  'user: "0:0"' \
+  'name: glm53-flash-jovian-cumem-broker' \
+  'target: /run/lmcache-cumem' \
+  'LMCACHE_MP_TRANSFER_MODE: lmcache_driven' \
+  'VLLM_WORKER_SHUTDOWN_TIMEOUT_SECONDS: "60"' \
+  'CUDA_VISIBLE_DEVICES: 0,1,2,3' \
+  '--separate-object-groups' \
+  '--supported-transfer-mode' \
+  '--chunk-size' \
+  '--l1-size-gb' \
+  '--served-model-name' \
+  'glm-5.3-flash' \
+  '--tensor-parallel-size' \
+  '--decode-context-parallel-size' \
+  '--max-model-len' \
+  '1048576' \
+  '--max-num-batched-tokens' \
+  '--max-num-seqs' \
+  '--kv-cache-memory' \
+  '33554432000' \
+  '--kv-cache-dtype' \
+  'fp8' \
+  '--gpu-memory-utilization' \
+  '0.945' \
+  '--max-cudagraph-capture-size' \
+  '128' \
+  '--enable-cumem-allocator' \
+  '--shutdown-timeout' \
+  '--enable-prefix-caching' \
+  '--enable-prompt-tokens-details' \
+  '"num_speculative_tokens":3' \
+  '"lmcache.mp.mp_transfer_mode":"lmcache_driven"'; do
+  require_rendered "${value}"
+done
+
+[[ "$(grep -Fc -- 'restart: unless-stopped' "${rendered}")" == 2 ]]
+[[ "$(grep -Fc -- "image: ${IMAGE_ID}" "${rendered}")" == 2 ]]
+
+grep -Fq -- "${IMAGE_ID}" "${LAUNCHER}"
+grep -Fq -- '--profile cumem' "${LAUNCHER}"
+grep -Fq -- 'stop -t 90 server' "${LAUNCHER}"
+grep -Fq -- 'stop -t 90 lmcache' "${LAUNCHER}"
+grep -Fq -- 'c43866fa9aecd18a7c9f49fa791fdad0655506da' "${README}"
+grep -Fq -- 'b39d501b26' "${README}"
+grep -Fq -- '88cff3d5a9' "${README}"
+grep -Fq -- '129/129' "${README}"
+grep -Fq -- '116/116' "${README}"
+
+printf 'GLM-5.3 cuMem Compose contract passed\n'


### PR DESCRIPTION
## Summary

Adds a standalone, optional cuMem CUDA-IPC LMCache profile for the GLM-5.3 Jovian Judgement stack proposed in #85.

- MTP3, TP4/DCP4, exact 1M context, batch 8192, explicit FP8 KV
- 31.25 GiB KV/GPU with measured DCP workspace headroom
- separate 48 GiB LMCache sidecar using direct cuMem POSIX-FD IPC
- one sidecar PID mapped across GPUs 0-3
- four isolated hybrid object groups
- immutable local image ID/source pins; no invented public registry reference
- explicit graceful worker and outer shutdown budgets
- reproducible launcher, Compose, contract test, and self-contained runbook

## Qualification

- cold 32k coherent; 64 L1 objects / 818,151,424 bytes
- automatic unregister: 4 allocations / 184 aliases -> 0 / 0; L1 preserved
- warm reload coherent; 24,576 external cached tokens
- unrelated sentinel coherent
- 524,288-token request coherent in 84.67 s at 31.25 GiB KV/GPU
- 32 GiB rejected: transient 512 MiB DCP all-gather OOM with ~149 MiB free
- 32k prefill 12,336 tok/s; TTFT 2.702 s
- C1 224.135 tok/s
- C8 806.988 tok/s; 305.480 steps/s; acceptance 2.642; queue/errors 0

## Validation

- Bash syntax and ShellCheck passed
- contract test passed
- Compose render passed with placeholder paths and digest-form image
- relative links passed

## Dependencies

- #85 GLM-5.3 Jovian production stack proposal
- local-inference-lab/LMCache#33
- local-inference-lab/vllm#526, #553, #554, #555

## AI assistance disclosure

AI assistance was used in preparing this contribution.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a four-GPU GLM-5.3 Flash deployment using Docker Compose, vLLM, and LMCache cumulative-memory transfer.
  * Added a launcher with commands for starting, restarting, stopping, inspecting, and viewing logs.
  * Added deployment health checks, GPU configuration, caching, speculative decoding, and tool/reasoning support.

* **Documentation**
  * Updated deployment qualification details, image references, and rendering instructions.

* **Tests**
  * Added contract checks to validate deployment configuration, launcher behavior, and documentation consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->