### PR TITLE
Allow GLM recurrent cache blocks to divide target blocks

### DIFF
--- a/models/glm-5.3-flash/build/serve-glm53-flash-cache-complete.sh
+++ b/models/glm-5.3-flash/build/serve-glm53-flash-cache-complete.sh
@@ -141,8 +141,8 @@ if [[ ${mamba_block_size} != auto ]]; then
   ((mamba_block_size % 64 == 0)) ||
     fail "GLM53_MAMBA_BLOCK_SIZE must be a multiple of 64; got ${mamba_block_size}"
   if [[ ${target_block_size} != auto ]] &&
-    ((mamba_block_size % target_block_size != 0)); then
-    fail "GLM53_MAMBA_BLOCK_SIZE must be a multiple of GLM53_TARGET_BLOCK_SIZE"
+    ((mamba_block_size % target_block_size != 0 && target_block_size % mamba_block_size != 0)); then
+    fail "GLM53_MAMBA_BLOCK_SIZE must be a multiple or divisor of GLM53_TARGET_BLOCK_SIZE"
   fi
 fi
 


### PR DESCRIPTION
Permit recurrent blocks to divide target blocks, matching the fine-grained prefix-hit geometry supported by vLLM PR #646. The current launcher rejects target2048 / recurrent256 before the engine can start, although that combination is used by the qualified LP27 cache integration.

This changes only the divisibility check and its error message. Positive-integer and multiple-of-64 validation remain active, and the independent LMCache chunk check is unchanged.

Validation: the original launcher rejects 2048/256. With this change, dry runs accept recurrent256, 2048, and 4096 with target2048, and reject recurrent384, 0, -64, and 65. Bash syntax and whitespace checks pass. The same launcher change is in the four-GPU LP27 image tested with DFlash2 K3, Marlin, TP4/DCP1, and 524288 context.

Related library changes: local-inference-lab/vllm#646, local-inference-lab/vllm#655, local-inference-lab/vllm#663. This launcher update requires an engine that supports the selected geometry.

Prepared with AI assistance and independent source review.
