### PR TITLE
build(glm53): parameterize LMCache server HTTP bind host

### DIFF
--- a/models/glm-5.3-flash/build/serve-glm53-flash-lmcache-cache-complete.sh
+++ b/models/glm-5.3-flash/build/serve-glm53-flash-lmcache-cache-complete.sh
@@ -23,6 +23,7 @@ require_positive_integer() {
 }
 
 readonly mp_host=${LMCACHE_MP_HOST:-127.0.0.1}
+readonly http_host=${LMCACHE_HTTP_HOST:-127.0.0.1}
 readonly mp_port=${LMCACHE_MP_PORT:-5555}
 readonly http_port=${LMCACHE_HTTP_PORT:-8085}
 readonly prometheus_port=${LMCACHE_PROMETHEUS_PORT:-9095}
@@ -48,6 +49,11 @@ require_positive_integer LMCACHE_MIN_SHM_GIB "${min_shm_gib}"
 if [[ ! ${mp_host} =~ ^[A-Za-z0-9_.:-]+$ ]]; then
   printf 'LMCACHE_MP_HOST contains unsupported characters: %s\n' \
     "${mp_host}" >&2
+  exit 2
+fi
+if [[ ! ${http_host} =~ ^[A-Za-z0-9_.:-]+$ ]]; then
+  printf 'LMCACHE_HTTP_HOST contains unsupported characters: %s\n' \
+    "${http_host}" >&2
   exit 2
 fi
 case "${transfer_mode}" in
@@ -130,7 +136,7 @@ lmcache_server=(
   --l1-size-gb "${LMCACHE_L1_SIZE_GB:-64}"
   --l1-init-size-gb "${LMCACHE_L1_INIT_SIZE_GB:-2}"
   --eviction-policy LRU
-  --http-host 127.0.0.1
+  --http-host "${http_host}"
   --http-port "${http_port}"
   --prometheus-port "${prometheus_port}"
 )

--- a/models/glm-5.3-flash/build/serve-glm53-flash-lmcache.sh
+++ b/models/glm-5.3-flash/build/serve-glm53-flash-lmcache.sh
@@ -23,6 +23,7 @@ require_positive_integer() {
 }
 
 readonly mp_host=${LMCACHE_MP_HOST:-127.0.0.1}
+readonly http_host=${LMCACHE_HTTP_HOST:-127.0.0.1}
 readonly mp_port=${LMCACHE_MP_PORT:-5555}
 readonly http_port=${LMCACHE_HTTP_PORT:-8085}
 readonly prometheus_port=${LMCACHE_PROMETHEUS_PORT:-9095}
@@ -46,6 +47,11 @@ require_positive_integer LMCACHE_MIN_SHM_GIB "${min_shm_gib}"
 if [[ ! ${mp_host} =~ ^[A-Za-z0-9_.:-]+$ ]]; then
   printf 'LMCACHE_MP_HOST contains unsupported characters: %s\n' \
     "${mp_host}" >&2
+  exit 2
+fi
+if [[ ! ${http_host} =~ ^[A-Za-z0-9_.:-]+$ ]]; then
+  printf 'LMCACHE_HTTP_HOST contains unsupported characters: %s\n' \
+    "${http_host}" >&2
   exit 2
 fi
 case "${transfer_mode}" in
@@ -91,7 +97,7 @@ lmcache_server=(
   --l1-use-lazy
   --l1-init-size-gb "${LMCACHE_L1_INIT_SIZE_GB:-2}"
   --eviction-policy LRU
-  --http-host 127.0.0.1
+  --http-host "${http_host}"
   --http-port "${http_port}"
   --prometheus-port "${prometheus_port}"
 )


### PR DESCRIPTION
The LMCache wrappers pass `--http-host 127.0.0.1` to `lmcache server`, which
overrides the CLI's `0.0.0.0` default. LMCache serves its Prometheus metrics
on the HTTP API port, so any deployment without `--network host` (Kubernetes:
Prometheus scrapes the pod IP) cannot scrape them at all. We hit this on the
r27 community image: zero `lmcache_mp_*` series for the stack, while
older-image stacks scrape fine with the same PodMonitor.

This makes the bind host configurable, mirroring how `LMCACHE_MP_HOST` is
already handled in these scripts:

```bash
readonly http_host=${LMCACHE_HTTP_HOST:-127.0.0.1}
# character-class check, same as mp_host
  --http-host "${http_host}"
```

The default stays `127.0.0.1`, so existing deployments are unaffected. To
make metrics scrapeable, set `LMCACHE_HTTP_HOST=0.0.0.0` and expose the port.

Both wrappers with the hardcode are changed:
`serve-glm53-flash-lmcache.sh` and
`serve-glm53-flash-lmcache-cache-complete.sh`.
`serve-glm53-flash-cache-complete.sh` has no hardcode and is untouched.

Testing: `bash -n` on both scripts, plus an argv-capture run with a stubbed
`lmcache` binary — default passes `127.0.0.1`, `LMCACHE_HTTP_HOST=0.0.0.0`
is substituted, and junk values are rejected before the server starts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring the LMCache HTTP host through the `LMCACHE_HTTP_HOST` environment variable.
  - The host defaults to `127.0.0.1` when no custom value is provided.
  - Host values are validated before the LMCache server starts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->