### PR TITLE
feat(launcher): add lmcache server flag passthrough and L2 prefetch policy env

### DIFF
--- a/models/glm-5.3-flash/build/serve-glm53-flash-lmcache-cache-complete.sh
+++ b/models/glm-5.3-flash/build/serve-glm53-flash-lmcache-cache-complete.sh
@@ -28,6 +28,9 @@ readonly http_port=${LMCACHE_HTTP_PORT:-8085}
 readonly prometheus_port=${LMCACHE_PROMETHEUS_PORT:-9095}
 readonly startup_timeout=${LMCACHE_STARTUP_TIMEOUT_SECONDS:-120}
 readonly transfer_mode=${LMCACHE_TRANSFER_MODE:-engine_driven}
+# 'retain' promotes L2-loaded chunks into L1; 'default' leaves them temporary.
+readonly prefetch_policy=${LMCACHE_L2_PREFETCH_POLICY:-retain}
+readonly extra_args=${LMCACHE_SERVER_EXTRA_ARGS:-}
 readonly broker_dir=${LMCACHE_CUMEM_BROKER_DIR:-/cache/lmcache-cumem}
 readonly chunk_size=${LMCACHE_CHUNK_SIZE:-4096}
 readonly target_token_budget=${LMCACHE_TARGET_TOKEN_BUDGET:-${MAX_NUM_BATCHED_TOKENS:-4096}}
@@ -59,6 +62,14 @@ case "${transfer_mode}" in
     ;;
 esac
 
+case "${prefetch_policy}" in
+  default | retain) ;;
+  *)
+    printf 'LMCACHE_L2_PREFETCH_POLICY must be default or retain; got %s\n' \
+      "${prefetch_policy}" >&2
+    exit 2
+    ;;
+esac
 shm_name=${LMCACHE_SHM_NAME:-}
 if [[ ${transfer_mode} == engine_driven && -z ${shm_name} ]]; then
   # The MP port is already exclusive under the host-network serving contract,
@@ -130,6 +141,7 @@ lmcache_server=(
   --l1-size-gb "${LMCACHE_L1_SIZE_GB:-64}"
   --l1-init-size-gb "${LMCACHE_L1_INIT_SIZE_GB:-2}"
   --eviction-policy LRU
+  --l2-prefetch-policy "${prefetch_policy}"
   --http-host 127.0.0.1
   --http-port "${http_port}"
   --prometheus-port "${prometheus_port}"
@@ -280,6 +292,11 @@ fi
 # override when supplied.
 if [[ ${transfer_mode} == engine_driven && -z ${GPU_MEMORY_UTILIZATION+x} ]]; then
   export GPU_MEMORY_UTILIZATION=0.950
+fi
+
+if [[ -n ${extra_args} ]]; then
+  # shellcheck disable=SC2086
+  lmcache_server+=(${extra_args})
 fi
 
 lmcache_server_command=("${lmcache_server[@]}")

--- a/models/glm-5.3-flash/build/serve-glm53-flash-lmcache.sh
+++ b/models/glm-5.3-flash/build/serve-glm53-flash-lmcache.sh
@@ -28,6 +28,9 @@ readonly http_port=${LMCACHE_HTTP_PORT:-8085}
 readonly prometheus_port=${LMCACHE_PROMETHEUS_PORT:-9095}
 readonly startup_timeout=${LMCACHE_STARTUP_TIMEOUT_SECONDS:-120}
 readonly transfer_mode=${LMCACHE_TRANSFER_MODE:-lmcache_driven}
+# 'retain' promotes L2-loaded chunks into L1; 'default' leaves them temporary.
+readonly prefetch_policy=${LMCACHE_L2_PREFETCH_POLICY:-retain}
+readonly extra_args=${LMCACHE_SERVER_EXTRA_ARGS:-}
 readonly broker_dir=${LMCACHE_CUMEM_BROKER_DIR:-/cache/lmcache-cumem}
 readonly chunk_size=${LMCACHE_CHUNK_SIZE:-4096}
 readonly target_token_budget=${LMCACHE_TARGET_TOKEN_BUDGET:-${MAX_NUM_BATCHED_TOKENS:-4096}}
@@ -57,6 +60,14 @@ case "${transfer_mode}" in
     ;;
 esac
 
+case "${prefetch_policy}" in
+  default | retain) ;;
+  *)
+    printf 'LMCACHE_L2_PREFETCH_POLICY must be default or retain; got %s\n' \
+      "${prefetch_policy}" >&2
+    exit 2
+    ;;
+esac
 case "${lmcache_kv_cache_dtype}" in
   fp8 | fp8_e4m3 | fp8_ds_mla | nvfp4_ds_mla) ;;
   *)
@@ -91,6 +102,7 @@ lmcache_server=(
   --l1-use-lazy
   --l1-init-size-gb "${LMCACHE_L1_INIT_SIZE_GB:-2}"
   --eviction-policy LRU
+  --l2-prefetch-policy "${prefetch_policy}"
   --http-host 127.0.0.1
   --http-port "${http_port}"
   --prometheus-port "${prometheus_port}"
@@ -211,6 +223,11 @@ if [[ ${transfer_mode} != engine_driven ]]; then
   export LMCACHE_CUMEM_BROKER_DIR="${broker_dir}"
   export LD_PRELOAD="/opt/lmcache/lib/liblmcache_cumem_shareable.so${LD_PRELOAD:+:${LD_PRELOAD}}"
   vllm_extra_args+=(--enable-cumem-allocator)
+fi
+
+if [[ -n ${extra_args} ]]; then
+  # shellcheck disable=SC2086
+  lmcache_server+=(${extra_args})
 fi
 
 "${lmcache_server[@]}" &


### PR DESCRIPTION
The wrapper family is inconsistent on L2 prefetch policy: the glm52-era
wrapper hardcodes `--l2-prefetch-policy retain` (`lmcache-mp-wrapper.sh`) —
but the glm-5.3-flash launchers have no policy flag at all, so they run the
lmcache server's own default (`default`: L2-loaded chunks stay temporary in
L1 and are re-loaded from L2 on every request).

This adds `LMCACHE_L2_PREFETCH_POLICY` (validated `default|retain`, fail fast
otherwise), defaulting to `retain` to match the family. Deployments that want
the server's temporary-L1 behavior set `default`.

Also adds `LMCACHE_SERVER_EXTRA_ARGS` (space-split, appended last, unset →
nothing) so server flags can be toggled without an image rebuild.

Applied to both launchers under `models/glm-5.3-flash/build/`. Tested with
`bash -n` and an argv-capture run against a stubbed `lmcache` binary: unset
envs → argv unchanged except the fixed policy pair; extras land last; bad
values are rejected before the server starts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configuration for controlling how data loaded from the secondary cache is promoted to the primary cache.
  - Added support for supplying additional server startup options through an environment variable.
  - The cache promotion setting defaults to retaining existing behavior and accepts only supported values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->